### PR TITLE
feat(covercalibrator): add ICoverCalibratorV2 async endpoints

### DIFF
--- a/python_alpaca_server/api/covercalibrator.py
+++ b/python_alpaca_server/api/covercalibrator.py
@@ -31,6 +31,17 @@ def create_router(devices: List[Device]):
             device.get_brightness(req),
         )
 
+    async def get_calibratorchanging(
+        req: Annotated[CommonRequest, Query()],
+        device: CoverCalibrator = Depends(
+            device_finder(devices, UrlDeviceType.CoverCalibrator)
+        ),
+    ) -> Response[bool]:
+        return Response[bool].from_request(
+            req,
+            device.get_calibratorchanging(req),
+        )
+
     async def get_calibratorstate(
         req: Annotated[CommonRequest, Query()],
         device: CoverCalibrator = Depends(
@@ -40,6 +51,17 @@ def create_router(devices: List[Device]):
         return Response[CalibratorState].from_request(
             req,
             device.get_calibratorstate(req),
+        )
+
+    async def get_covermoving(
+        req: Annotated[CommonRequest, Query()],
+        device: CoverCalibrator = Depends(
+            device_finder(devices, UrlDeviceType.CoverCalibrator)
+        ),
+    ) -> Response[bool]:
+        return Response[bool].from_request(
+            req,
+            device.get_covermoving(req),
         )
 
     async def get_coverstate(
@@ -125,9 +147,19 @@ def create_router(devices: List[Device]):
     )(get_brightness)
 
     router.get(
+        "/covercalibrator/{device_number}/calibratorchanging",
+        **common_endpoint_parameters,
+    )(get_calibratorchanging)
+
+    router.get(
         "/covercalibrator/{device_number}/calibratorstate",
         **common_endpoint_parameters,
     )(get_calibratorstate)
+
+    router.get(
+        "/covercalibrator/{device_number}/covermoving",
+        **common_endpoint_parameters,
+    )(get_covermoving)
 
     router.get(
         "/covercalibrator/{device_number}/coverstate",

--- a/python_alpaca_server/devices/covercalibrator.py
+++ b/python_alpaca_server/devices/covercalibrator.py
@@ -40,6 +40,14 @@ class CoverCalibrator(Device):
         raise NotImplementedError(req)
 
     @abstractmethod
+    def get_calibratorchanging(self, req: CommonRequest) -> bool:
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def get_covermoving(self, req: CommonRequest) -> bool:
+        raise NotImplementedError(req)
+
+    @abstractmethod
     def get_maxbrightness(self, req: CommonRequest) -> int:
         raise NotImplementedError(req)
 


### PR DESCRIPTION
## Summary

- Adds `calibratorchanging` and `covermoving` GET endpoints to the CoverCalibrator device
- These are ICoverCalibratorV2 (Platform 7) async completion properties

## Details

These mandatory properties indicate when async operations are in progress:

| Endpoint | Description |
|----------|-------------|
| `GET /covercalibrator/{device_number}/calibratorchanging` | True when calibrator is not ready (stabilizing or shutting down) |
| `GET /covercalibrator/{device_number}/covermoving` | True while cover is moving |

Both return `boolean` values and are used to determine completion of async `CalibratorOn()`, `CalibratorOff()`, `OpenCover()`, and `CloseCover()` operations.

Fixes #11