### PR TITLE
feat(switch): add ISwitchV3 async endpoints

### DIFF
--- a/python_alpaca_server/api/switch.py
+++ b/python_alpaca_server/api/switch.py
@@ -134,6 +134,51 @@ def create_router(devices: List[Device]):
             device.put_setswitchvalue(req),
         )
 
+    async def get_canasync(
+        req: Annotated[IdRequest, Query()],
+        device: Switch = Depends(device_finder(devices, UrlDeviceType.Switch)),
+    ) -> Response[bool]:
+        return Response[bool].from_request(
+            req,
+            device.get_canasync(req),
+        )
+
+    async def get_statechangecomplete(
+        req: Annotated[IdRequest, Query()],
+        device: Switch = Depends(device_finder(devices, UrlDeviceType.Switch)),
+    ) -> Response[bool]:
+        return Response[bool].from_request(
+            req,
+            device.get_statechangecomplete(req),
+        )
+
+    async def put_cancelasync(
+        req: Annotated[IdRequest, Query()],
+        device: Switch = Depends(device_finder(devices, UrlDeviceType.Switch)),
+    ) -> Response[None]:
+        return Response[None].from_request(
+            req,
+            device.put_cancelasync(req),
+        )
+
+    async def put_setasync(
+        req: Annotated[PutIdStateRequest, Query()],
+        device: Switch = Depends(device_finder(devices, UrlDeviceType.Switch)),
+    ) -> Response[None]:
+        return Response[None].from_request(
+            req,
+            device.put_setasync(req),
+        )
+
+    async def put_setasyncvalue(
+        req: Annotated[PutIdValueRequest, Query()],
+        device: Switch = Depends(device_finder(devices, UrlDeviceType.Switch)),
+    ) -> Response[None]:
+        return Response[None].from_request(
+            req,
+            device.put_setasyncvalue(req),
+        )
+
     router.get(
         "/switch/{device_number}/maxswitch",
         **common_endpoint_parameters,
@@ -193,5 +238,30 @@ def create_router(devices: List[Device]):
         "/switch/{device_number}/setswitchvalue",
         **common_endpoint_parameters,
     )(put_setswitchvalue)
+
+    router.get(
+        "/switch/{device_number}/canasync",
+        **common_endpoint_parameters,
+    )(get_canasync)
+
+    router.get(
+        "/switch/{device_number}/statechangecomplete",
+        **common_endpoint_parameters,
+    )(get_statechangecomplete)
+
+    router.put(
+        "/switch/{device_number}/cancelasync",
+        **common_endpoint_parameters,
+    )(put_cancelasync)
+
+    router.put(
+        "/switch/{device_number}/setasync",
+        **common_endpoint_parameters,
+    )(put_setasync)
+
+    router.put(
+        "/switch/{device_number}/setasyncvalue",
+        **common_endpoint_parameters,
+    )(put_setasyncvalue)
 
     return router

--- a/python_alpaca_server/devices/switch.py
+++ b/python_alpaca_server/devices/switch.py
@@ -61,3 +61,23 @@ class Switch(Device):
     @abstractmethod
     def put_setswitchvalue(self, req: PutIdValueRequest) -> None:
         raise NotImplementedError(req)
+
+    @abstractmethod
+    def get_canasync(self, req: IdRequest) -> bool:
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def get_statechangecomplete(self, req: IdRequest) -> bool:
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def put_cancelasync(self, req: IdRequest) -> None:
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def put_setasync(self, req: PutIdStateRequest) -> None:
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def put_setasyncvalue(self, req: PutIdValueRequest) -> None:
+        raise NotImplementedError(req)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -104,6 +104,21 @@ class MockSwitch(Switch):
     def put_setswitchvalue(self, req: PutIdValueRequest) -> None:
         pass
 
+    def get_canasync(self, req: IdRequest) -> bool:
+        return False
+
+    def get_statechangecomplete(self, req: IdRequest) -> bool:
+        return True
+
+    def put_cancelasync(self, req: IdRequest) -> None:
+        pass
+
+    def put_setasync(self, req: PutIdStateRequest) -> None:
+        pass
+
+    def put_setasyncvalue(self, req: PutIdValueRequest) -> None:
+        pass
+
 
 class TestSwitchStepProperty:
     """Tests for the switchstep property on Switch devices."""


### PR DESCRIPTION
## Summary

- Adds ISwitchV3 (Platform 7) async operation endpoints to the Switch device
- Updates MockSwitch in tests to implement the new abstract methods

## New Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/switch/{device_number}/canasync` | GET | Whether the specified switch can operate asynchronously |
| `/switch/{device_number}/statechangecomplete` | GET | True if the last SetAsync/SetAsyncValue has completed |
| `/switch/{device_number}/cancelasync` | PUT | Cancels an in-progress asynchronous state change operation |
| `/switch/{device_number}/setasync` | PUT | Set a switch to the specified boolean state asynchronously |
| `/switch/{device_number}/setasyncvalue` | PUT | Set a switch to the specified float value asynchronously |

## Files Changed

- `python_alpaca_server/devices/switch.py` - Added 5 abstract methods
- `python_alpaca_server/api/switch.py` - Added 5 router endpoints
- `tests/test_switch.py` - Updated MockSwitch with new method implementations

Fixes #12