### PR TITLE
docs: add implementer-focused docstrings to device base classes

### DIFF
--- a/python_alpaca_server/device.py
+++ b/python_alpaca_server/device.py
@@ -45,6 +45,30 @@ class UrlDeviceType(str, Enum):
 
 
 class Device(ABC):
+    """Base class for all ASCOM Alpaca device implementations.
+
+    Subclass this to implement a concrete device driver. Each abstract method
+    corresponds to an ASCOM Alpaca endpoint that your driver must support.
+
+    Your subclass must:
+        - Call ``super().__init__(device_type, unique_id)`` in your constructor
+        - Implement all abstract methods defined here and in device-specific
+          subclasses (e.g., ``Focuser``, ``Camera``)
+
+    Attributes:
+        device_type: The ASCOM device type (Camera, Focuser, etc.).
+        unique_id: A globally unique identifier for this device instance.
+        device_number: Assigned by the server; do not set directly.
+
+    Example:
+        >>> class MyFocuser(Focuser):
+        ...     def __init__(self):
+        ...         super().__init__(unique_id="my-focuser-001")
+        ...
+        ...     def get_connected(self, req: CommonRequest) -> bool:
+        ...         return self._is_connected
+    """
+
     def __init__(self, device_type: DeviceType, unique_id: str):
         self.device_type = device_type
         self.unique_id = unique_id
@@ -52,50 +76,253 @@ class Device(ABC):
 
     @abstractmethod
     def put_action(self, req: ActionRequest) -> str:
+        """Invoke a device-specific custom action.
+
+        Implement this to support custom actions beyond the standard ASCOM
+        interface. The action name must be listed in ``get_supportedactions()``.
+
+        Args:
+            req: The action request containing:
+                - ``action``: Name of the action to invoke (from SupportedActions)
+                - ``parameters``: Action-specific parameter string, or empty
+
+        Returns:
+            Action-specific response string. Define the format in your
+            documentation.
+
+        Raises:
+            NotImplementedException: Raise if no custom actions are supported.
+            ActionNotImplementedException: Raise if the requested action name
+                is not recognized.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_command_blind(self, req: CommandRequest) -> None:
+        """Transmit an arbitrary command string without waiting for a response.
+
+        .. deprecated::
+            Use ``put_action()`` and ``get_supportedactions()`` instead.
+
+        Implement this only if your hardware requires raw command support for
+        legacy compatibility.
+
+        Args:
+            req: The command request containing:
+                - ``command``: The literal command string to transmit
+                - ``raw``: If True, send as-is; if False, add protocol framing
+
+        Raises:
+            NotImplementedException: Raise if raw commands are not supported.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_command_bool(self, req: CommandRequest) -> bool:
+        """Transmit a command string and return a boolean response.
+
+        .. deprecated::
+            Use ``put_action()`` and ``get_supportedactions()`` instead.
+
+        Implement this only if your hardware requires raw command support for
+        legacy compatibility.
+
+        Args:
+            req: The command request containing:
+                - ``command``: The literal command string to transmit
+                - ``raw``: If True, send as-is; if False, add protocol framing
+
+        Returns:
+            Boolean response from the device.
+
+        Raises:
+            NotImplementedException: Raise if raw commands are not supported.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_command_string(self, req: CommandRequest) -> str:
+        """Transmit a command string and return a string response.
+
+        .. deprecated::
+            Use ``put_action()`` and ``get_supportedactions()`` instead.
+
+        Implement this only if your hardware requires raw command support for
+        legacy compatibility.
+
+        Args:
+            req: The command request containing:
+                - ``command``: The literal command string to transmit
+                - ``raw``: If True, send as-is; if False, add protocol framing
+
+        Returns:
+            String response from the device.
+
+        Raises:
+            NotImplementedException: Raise if raw commands are not supported.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_connected(self, req: CommonRequest) -> bool:
+        """Return whether the device is currently connected.
+
+        Implement this to return your device's connection state. This should
+        reflect whether communication with the hardware is active.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            True if connected to the hardware, False otherwise.
+
+        Raises:
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_connected(self, req: PutConnectedRequest) -> None:
+        """Connect to or disconnect from the device hardware.
+
+        Implement this to establish or terminate the connection to your
+        hardware. When ``req.connected`` is True, initialize the hardware
+        connection. When False, release all hardware resources.
+
+        Your implementation should:
+            - Validate hardware availability before connecting
+            - Clean up resources fully when disconnecting
+            - Be idempotent (connecting when connected is a no-op)
+
+        Args:
+            req: The request containing:
+                - ``connected``: True to connect, False to disconnect
+
+        Raises:
+            DriverException: Raise if the connection attempt fails.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_description(self, req: CommonRequest) -> str:
+        """Return a description of the device.
+
+        Implement this to return a human-readable description including
+        manufacturer and model information.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Description string (maximum 64 characters). May contain any
+            ASCII characters.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_driverinfo(self, req: CommonRequest) -> str:
+        """Return descriptive and version information about the driver.
+
+        Implement this to return detailed information about your driver
+        implementation. This may be a multi-line string with extensive
+        details.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Driver information string. May contain line endings and be
+            hundreds to thousands of characters long.
+
+        Raises:
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_driverversion(self, req: CommonRequest) -> str:
+        """Return the driver version string.
+
+        Implement this to return your driver's version number.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Version string in "n.n" format (e.g., "1.0", "2.1").
+
+        Raises:
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_interfaceversion(self, req: CommonRequest) -> int:
+        """Return the ASCOM interface version supported by this driver.
+
+        Implement this to return the version of the ASCOM device interface
+        that your driver implements. Check the ASCOM documentation for the
+        current version number for your device type.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Interface version number (e.g., 3 for IFocuserV3, 4 for IFocuserV4).
+
+        Raises:
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_name(self, req: CommonRequest) -> str:
+        """Return the short name of the device.
+
+        Implement this to return a brief display name for the device,
+        suitable for use in user interface elements like dropdown lists.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Short display name for the device.
+
+        Raises:
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_supportedactions(self, req: CommonRequest) -> List[str]:
+        """Return the list of custom action names supported by this driver.
+
+        Implement this to advertise which custom actions are available via
+        ``put_action()``. Return an empty list if no custom actions are
+        supported.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            List of action name strings. Return an empty list if no custom
+            actions are supported.
+
+        Raises:
+            DriverException: Raise for unexpected errors.
+        """
         raise NotImplementedError(req)
 
 

--- a/python_alpaca_server/devices/covercalibrator.py
+++ b/python_alpaca_server/devices/covercalibrator.py
@@ -6,6 +6,37 @@ from ..request import CommonRequest, PutBrightnessRequest
 
 
 class CalibratorState(int, Enum):
+    """
+    Describes the state of a calibration device.
+
+    Use this enum to report calibrator status from ``get_calibratorstate()``.
+
+    States:
+        NotPresent (0): This device does not have a calibration capability.
+            Return this if your device is cover-only with no light source.
+
+        Off (1): The calibrator is off. The ``get_brightness()`` value must
+            be 0 when in this state.
+
+        NotReady (2): The calibrator is stabilising or not yet in the commanded
+            state. Return this during async operations when ``put_calibratoron()``
+            or ``put_calibratoroff()`` has been called but the operation is still
+            in progress. ``get_calibratorchanging()`` must return True while in
+            this state.
+
+        Ready (3): The calibrator is ready for use. The light is on and stable
+            at the commanded brightness level. ``get_calibratorchanging()`` must
+            return False when in this state.
+
+        Unknown (4): The calibrator state is unknown. Use this only when the
+            device cannot determine its actual state (e.g., after initialization
+            before first status query).
+
+        Error (5): The calibrator encountered an error when changing state.
+            Use this instead of raising an exception from ``get_calibratorstate()``
+            when something goes wrong during an operation.
+    """
+
     NotPresent = 0
     Off = 1
     NotReady = 2
@@ -15,6 +46,36 @@ class CalibratorState(int, Enum):
 
 
 class CoverState(int, Enum):
+    """
+    Describes the state of a telescope cover.
+
+    Use this enum to report cover status from ``get_coverstate()``.
+
+    States:
+        NotPresent (0): This device does not have a cover that can be closed
+            independently. Return this if your device is calibrator-only with
+            no motorized cover.
+
+        Closed (1): The cover is closed. ``get_covermoving()`` must return False
+            when in this state.
+
+        Moving (2): The cover is moving to a new position. Return this during
+            async operations when ``put_opencover()`` or ``put_closecover()`` has
+            been called but the operation is still in progress.
+            ``get_covermoving()`` must return True while in this state.
+
+        Open (3): The cover is open. ``get_covermoving()`` must return False
+            when in this state.
+
+        Unknown (4): The state of the cover is unknown. Use this only when the
+            device cannot determine its actual position (e.g., after a halt
+            operation or after initialization before first status query).
+
+        Error (5): The device encountered an error when changing state.
+            Use this instead of raising an exception from ``get_coverstate()``
+            when something goes wrong during an operation.
+    """
+
     NotPresent = 0
     Closed = 1
     Moving = 2
@@ -24,49 +85,344 @@ class CoverState(int, Enum):
 
 
 class CoverCalibrator(Device):
+    """
+    Abstract base class for ASCOM CoverCalibrator devices.
+
+    A CoverCalibrator device can have a calibrator (flat panel light source),
+    a motorized cover, or both. Implement the appropriate methods based on your
+    device's capabilities.
+
+    **Calibrator-only device:** Implement calibrator methods and return
+    ``CoverState.NotPresent`` from ``get_coverstate()``.
+
+    **Cover-only device:** Implement cover methods and return
+    ``CalibratorState.NotPresent`` from ``get_calibratorstate()``.
+
+    **Combined device:** Implement all methods.
+
+    Async Behavior:
+        The calibrator and cover operations (``put_calibratoron()``,
+        ``put_calibratoroff()``, ``put_opencover()``, ``put_closecover()``)
+        are non-blocking. Your implementation should:
+
+        1. Initiate the operation and return immediately
+        2. Update state properties to reflect the in-progress operation
+        3. Track completion internally and update state when done
+
+        Clients poll ``get_calibratorchanging()`` or ``get_covermoving()`` to
+        detect completion.
+
+    Example:
+        A simple flat panel implementation::
+
+            class MyFlatPanel(CoverCalibrator):
+                def __init__(self):
+                    super().__init__("my-flat-panel-123")
+                    self._brightness = 0
+                    self._max_brightness = 255
+
+                def get_calibratorstate(self, req):
+                    if self._brightness > 0:
+                        return CalibratorState.Ready
+                    return CalibratorState.Off
+
+                def get_coverstate(self, req):
+                    return CoverState.NotPresent  # No cover on this device
+
+                # ... implement remaining methods
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.CoverCalibrator, unique_id)
 
     @abstractmethod
     def get_brightness(self, req: CommonRequest) -> int:
+        """
+        Return the current calibrator brightness.
+
+        Return the brightness in the range 0 (completely off) to the value
+        returned by ``get_maxbrightness()`` (fully on).
+
+        Your implementation should:
+            - Return 0 when ``get_calibratorstate()`` returns ``CalibratorState.Off``
+            - Return the actual commanded brightness when the calibrator is on
+
+        Raise:
+            PropertyNotImplementedException: If ``get_calibratorstate()`` returns
+                ``CalibratorState.NotPresent`` (no calibrator on this device).
+            NotConnectedException: If the device is not connected.
+
+        Returns:
+            int: The current brightness level (0 to max_brightness).
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_calibratorstate(self, req: CommonRequest) -> CalibratorState:
+        """
+        Return the state of the calibration device.
+
+        Your implementation should:
+            - Return ``CalibratorState.NotPresent`` if no calibrator exists
+            - Return ``CalibratorState.Off`` when the calibrator is off
+            - Return ``CalibratorState.NotReady`` during async operations
+              (stabilizing after ``put_calibratoron()`` or shutting down after
+              ``put_calibratoroff()``)
+            - Return ``CalibratorState.Ready`` when on and stable
+            - Return ``CalibratorState.Error`` if an error occurred during
+              state change (do not raise an exception)
+
+        Important:
+            This method must never raise ``PropertyNotImplementedException``.
+            Return ``CalibratorState.NotPresent`` for devices without a calibrator.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+
+        Returns:
+            CalibratorState: The current calibrator state.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_coverstate(self, req: CommonRequest) -> CoverState:
+        """
+        Return the state of the device cover.
+
+        Your implementation should:
+            - Return ``CoverState.NotPresent`` if no cover exists
+            - Return ``CoverState.Closed`` when the cover is fully closed
+            - Return ``CoverState.Open`` when the cover is fully open
+            - Return ``CoverState.Moving`` during async operations (while opening
+              or closing after ``put_opencover()`` or ``put_closecover()``)
+            - Return ``CoverState.Unknown`` if position cannot be determined
+              (e.g., after ``put_haltcover()`` mid-movement)
+            - Return ``CoverState.Error`` if an error occurred during state
+              change (do not raise an exception)
+
+        Important:
+            This method must never raise ``PropertyNotImplementedException``.
+            Return ``CoverState.NotPresent`` for devices without a cover.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+
+        Returns:
+            CoverState: The current cover state.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_calibratorchanging(self, req: CommonRequest) -> bool:
+        """
+        Return True while the calibrator is changing state.
+
+        Implement this to indicate when an async ``put_calibratoron()`` or
+        ``put_calibratoroff()`` operation is in progress.
+
+        Your implementation should:
+            - Return True immediately after ``put_calibratoron()`` is called
+              if the calibrator needs time to stabilize
+            - Return True immediately after ``put_calibratoroff()`` is called
+              if the calibrator needs time to safely shut down
+            - Return False when the calibrator has reached a stable state
+              (``CalibratorState.Ready``, ``CalibratorState.Off``, or
+              ``CalibratorState.Error``)
+            - Return False if no calibrator is present
+
+        This is the correct property for clients to poll to determine when
+        async calibrator operations have completed.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+
+        Returns:
+            bool: True if the calibrator is changing state, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_covermoving(self, req: CommonRequest) -> bool:
+        """
+        Return True while the cover is moving.
+
+        Implement this to indicate when an async ``put_opencover()`` or
+        ``put_closecover()`` operation is in progress.
+
+        Your implementation should:
+            - Return True immediately after ``put_opencover()`` or
+              ``put_closecover()`` is called
+            - Return False when the cover has reached its final position
+              (``CoverState.Open``, ``CoverState.Closed``, ``CoverState.Unknown``,
+              or ``CoverState.Error``)
+            - Return False if no cover is present
+
+        This is the correct property for clients to poll to determine when
+        async cover operations have completed.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+
+        Returns:
+            bool: True if the cover is moving, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_maxbrightness(self, req: CommonRequest) -> int:
+        """
+        Return the maximum brightness value supported by the calibrator.
+
+        The return value defines the valid range for the ``brightness``
+        parameter in ``put_calibratoron()``, which is 0 to this value.
+
+        Your implementation should:
+            - Return a positive integer between 1 and 2,147,483,647
+            - Return 1 if the calibrator can only be "off" or "on" (no dimming)
+            - Return a higher value for dimmable calibrators (e.g., 255 for
+              8-bit PWM control, giving 256 levels including off)
+
+        Raise:
+            PropertyNotImplementedException: If ``get_calibratorstate()`` returns
+                ``CalibratorState.NotPresent`` (no calibrator on this device).
+            NotConnectedException: If the device is not connected.
+
+        Returns:
+            int: The maximum brightness value (1 to 2,147,483,647).
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_calibratoroff(self, req: CommonRequest) -> None:
+        """
+        Turn the calibrator off.
+
+        This is a non-blocking (async) method. Your implementation should
+        initiate the shut-down process and return immediately.
+
+        Your implementation should:
+            - Start turning off the calibrator and return immediately
+            - If the calibrator needs time to safely shut down, set
+              ``get_calibratorstate()`` to return ``CalibratorState.NotReady``
+              and ``get_calibratorchanging()`` to return True
+            - When shut down is complete, set ``get_calibratorstate()`` to
+              return ``CalibratorState.Off`` and ``get_calibratorchanging()``
+              to return False
+            - Set ``get_brightness()`` to return 0 when off
+            - If an error occurs during shut down, set ``get_calibratorstate()``
+              to return ``CalibratorState.Error``
+
+        Raise:
+            MethodNotImplementedException: If ``get_calibratorstate()`` returns
+                ``CalibratorState.NotPresent`` (no calibrator on this device).
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_calibratoron(self, req: PutBrightnessRequest) -> None:
+        """
+        Turn the calibrator on at the specified brightness.
+
+        This is a non-blocking (async) method. Your implementation should
+        initiate the operation and return immediately.
+
+        The brightness value is available via ``req.Brightness`` and must be
+        in the range 0 to the value returned by ``get_maxbrightness()``.
+
+        Your implementation should:
+            - Validate the brightness value and raise ``InvalidValueException``
+              if out of range
+            - Start turning on the calibrator and return immediately
+            - If the calibrator needs time to stabilize, set
+              ``get_calibratorstate()`` to return ``CalibratorState.NotReady``
+              and ``get_calibratorchanging()`` to return True
+            - When ready, set ``get_calibratorstate()`` to return
+              ``CalibratorState.Ready`` and ``get_calibratorchanging()``
+              to return False
+            - Update ``get_brightness()`` to return the commanded brightness
+            - If an error occurs, set ``get_calibratorstate()`` to return
+              ``CalibratorState.Error``
+
+        Args:
+            req: Request containing the ``Brightness`` value to set.
+
+        Raise:
+            InvalidValueException: If ``req.Brightness`` is outside the range
+                0 to ``get_maxbrightness()``.
+            MethodNotImplementedException: If ``get_calibratorstate()`` returns
+                ``CalibratorState.NotPresent`` (no calibrator on this device).
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_closecover(self, req: CommonRequest) -> None:
+        """
+        Initiate cover closing.
+
+        This is a non-blocking (async) method. Your implementation should
+        start the closing operation and return immediately.
+
+        Your implementation should:
+            - Start closing the cover and return immediately
+            - Set ``get_coverstate()`` to return ``CoverState.Moving`` and
+              ``get_covermoving()`` to return True while closing
+            - When fully closed, set ``get_coverstate()`` to return
+              ``CoverState.Closed`` and ``get_covermoving()`` to return False
+            - If an error occurs during closing, set ``get_coverstate()`` to
+              return ``CoverState.Error`` (not ``CoverState.Unknown``)
+
+        Raise:
+            MethodNotImplementedException: If ``get_coverstate()`` returns
+                ``CoverState.NotPresent`` (no cover on this device).
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_haltcover(self, req: CommonRequest) -> None:
+        """
+        Stop any cover movement in progress.
+
+        This must be a short-lived, synchronous method that stops cover
+        movement as quickly as possible.
+
+        Your implementation should:
+            - Stop cover movement immediately
+            - Set ``get_covermoving()`` to return False
+            - Set ``get_coverstate()`` to return ``CoverState.Open``,
+              ``CoverState.Closed``, or ``CoverState.Unknown`` as appropriate
+              for the cover's final position
+
+        Raise:
+            MethodNotImplementedException: If ``get_coverstate()`` returns
+                ``CoverState.NotPresent``, or if cover movement cannot be
+                interrupted on this device.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_opencover(self, req: CommonRequest) -> None:
+        """
+        Initiate cover opening.
+
+        This is a non-blocking (async) method. Your implementation should
+        start the opening operation and return immediately.
+
+        Your implementation should:
+            - Start opening the cover and return immediately
+            - Set ``get_coverstate()`` to return ``CoverState.Moving`` and
+              ``get_covermoving()`` to return True while opening
+            - When fully open, set ``get_coverstate()`` to return
+              ``CoverState.Open`` and ``get_covermoving()`` to return False
+            - If an error occurs during opening, set ``get_coverstate()`` to
+              return ``CoverState.Error`` (not ``CoverState.Unknown``)
+
+        Raise:
+            MethodNotImplementedException: If ``get_coverstate()`` returns
+                ``CoverState.NotPresent`` (no cover on this device).
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)

--- a/python_alpaca_server/devices/dome.py
+++ b/python_alpaca_server/devices/dome.py
@@ -11,6 +11,23 @@ from ..request import (
 
 
 class ShutterState(int, Enum):
+    """Shutter or roof state enumeration.
+
+    Represents the current operational state of a dome shutter or roll-off roof.
+    Use this enum when implementing `get_shutterstatus()` to report the current
+    state of the shutter mechanism.
+
+    Attributes:
+        Open: The shutter or roof is fully open.
+        Closed: The shutter or roof is fully closed.
+        Opening: The shutter or roof is currently opening. Return this state
+            immediately after `put_openshutter()` is called.
+        Closing: The shutter or roof is currently closing. Return this state
+            immediately after `put_closeshutter()` is called.
+        Error: The shutter or roof has encountered a problem and its state
+            is unknown or it cannot be controlled.
+    """
+
     Open = 0
     Closed = 1
     Opening = 2
@@ -19,105 +36,654 @@ class ShutterState(int, Enum):
 
 
 class Dome(Device):
+    """Base class for ASCOM Dome device implementations.
+
+    Implement this class to create a dome controller that can manage dome rotation,
+    shutter control, and telescope slaving. The dome interface supports various
+    configurations including rotating domes with shutters, roll-off roofs, and
+    clamshell designs.
+
+    Your implementation should handle asynchronous operations properly. All slewing
+    and shutter operations are non-blocking - they start the operation and return
+    immediately. Clients monitor progress via `get_slewing()` and `get_shutterstatus()`.
+
+    Capability methods (`get_canfindhome()`, `get_canpark()`, etc.) must return
+    consistent values and match the actual capabilities of your hardware. If a
+    capability method returns False, the corresponding operation method should
+    raise `MethodNotImplementedException`.
+
+    Example:
+        A minimal dome implementation for a roll-off roof (no azimuth control)::
+
+            class RollOffRoof(Dome):
+                def get_cansetazimuth(self, req: CommonRequest) -> bool:
+                    return False  # Roll-off roofs don't rotate
+
+                def get_cansetshutter(self, req: CommonRequest) -> bool:
+                    return True  # Can open/close the roof
+
+                # ... implement other required methods
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.Dome, unique_id)
 
     @abstractmethod
     def get_altitude(self, req: CommonRequest) -> float:
+        """Return the dome opening's altitude in degrees.
+
+        Return the altitude of the part of the sky that is exposed through
+        the dome opening. This is typically controlled by a movable shutter
+        slit or adjustable opening within a rotating dome.
+
+        Your implementation should return a value between 0 (horizon) and 90
+        (zenith) degrees.
+
+        Raise `PropertyNotImplementedException` if your dome does not support
+        altitude control. In this case, `get_cansetaltitude()` must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            The altitude in degrees (0-90, horizon to zenith).
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_athome(self, req: CommonRequest) -> bool:
+        """Return True if the dome is at its home position.
+
+        Return whether the dome is currently at its home position. The home
+        position is typically a known reference point used for calibration
+        and synchronization of the azimuth encoder.
+
+        Your implementation should return False as soon as any azimuth slew
+        operation moves the dome away from home. Do not use this property
+        to indicate completion of `put_findhome()` - clients should use
+        `get_slewing()` for that purpose.
+
+        Raise `PropertyNotImplementedException` if your dome does not support
+        homing. In this case, `get_canfindhome()` must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if the dome is at home, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_atpark(self, req: CommonRequest) -> bool:
+        """Return True if the dome is at its park position.
+
+        Return whether the dome is currently at its programmed park position.
+        The park position is typically a safe position for closing down the
+        observatory.
+
+        Your implementation should return False as soon as any azimuth slew
+        operation moves the dome away from the park position. Do not use this
+        property to indicate completion of `put_park()` - clients should use
+        `get_slewing()` for that purpose.
+
+        Raise `PropertyNotImplementedException` if your dome does not support
+        parking. In this case, `get_canpark()` must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if the dome is parked, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_azimuth(self, req: CommonRequest) -> float:
+        """Return the dome's current azimuth in degrees.
+
+        Return the azimuth of the dome opening to the sky. Azimuth uses the
+        standard convention: 0 is North, 90 is East, 180 is South, 270 is West.
+
+        Your implementation should return the current azimuth position regardless
+        of whether the shutter is open or closed. Do not use this property to
+        determine if `put_slewtoazimuth()` has completed - clients should use
+        `get_slewing()` for that purpose.
+
+        Raise `PropertyNotImplementedException` if your dome does not support
+        azimuth control (e.g., a roll-off roof). In this case, `get_cansetazimuth()`
+        must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            The azimuth in degrees (0-360, North-referenced, clockwise).
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_canfindhome(self, req: CommonRequest) -> bool:
+        """Return True if the dome can find its home position.
+
+        Indicate whether your dome hardware supports a home-finding operation
+        via `put_findhome()`. Return True if the dome has a home sensor or
+        other mechanism to locate and synchronize to a reference position.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if `put_findhome()` is supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_canpark(self, req: CommonRequest) -> bool:
+        """Return True if the dome can be parked.
+
+        Indicate whether your dome hardware supports parking via `put_park()`.
+        Return True if the dome can slew to a predefined park position.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if `put_park()` is supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_cansetaltitude(self, req: CommonRequest) -> bool:
+        """Return True if the dome opening altitude can be controlled.
+
+        Indicate whether your dome hardware supports altitude control via
+        `put_slewtoaltitude()`. Return True if the dome has an adjustable
+        shutter slit or similar mechanism for controlling the vertical
+        position of the opening.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if `put_slewtoaltitude()` is supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_cansetazimuth(self, req: CommonRequest) -> bool:
+        """Return True if the dome azimuth can be controlled.
+
+        Indicate whether your dome hardware supports azimuth control via
+        `put_slewtoazimuth()`. Return True for rotating domes. Return False
+        for roll-off roofs and other non-rotating enclosures.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability. Clients can detect a roll-off roof by
+        checking that this returns False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if `put_slewtoazimuth()` is supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_cansetpark(self, req: CommonRequest) -> bool:
+        """Return True if the park position can be configured.
+
+        Indicate whether your dome hardware supports setting the park position
+        via `put_setpark()`. Return True if the user can define where the dome
+        should park.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if `put_setpark()` is supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_cansetshutter(self, req: CommonRequest) -> bool:
+        """Return True if the shutter can be opened and closed.
+
+        Indicate whether your dome hardware supports shutter control via
+        `put_openshutter()` and `put_closeshutter()`. Return True for domes
+        with motorized shutters or roll-off roofs. Return False if there is
+        no controllable shutter mechanism.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if shutter operations are supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_canslave(self, req: CommonRequest) -> bool:
+        """Return True if the dome can slave to the telescope.
+
+        Indicate whether your dome is part of an integrated telescope/dome
+        control system that supports automatic slaving. When slaved, the dome
+        automatically tracks the telescope to keep the opening aligned with
+        the telescope's optical path.
+
+        Return True only if your system provides this integrated slaving
+        capability. Most standalone dome controllers should return False.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if telescope slaving is supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_cansyncazimuth(self, req: CommonRequest) -> bool:
+        """Return True if the azimuth can be synchronized.
+
+        Indicate whether your dome hardware supports azimuth synchronization
+        via `put_synctoazimuth()`. Return True if the dome's azimuth encoder
+        can be set to a known value without physically moving the dome.
+
+        This value must remain constant while connected and must accurately
+        reflect hardware capability.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if `put_synctoazimuth()` is supported, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_shutterstatus(self, req: CommonRequest) -> ShutterState:
+        """Return the current shutter state.
+
+        Return the current operational state of the dome shutter or roll-off
+        roof. This is the correct way to monitor shutter operations in progress.
+
+        Your implementation must return `ShutterState.Opening` immediately after
+        `put_openshutter()` is called, and `ShutterState.Closing` immediately
+        after `put_closeshutter()` is called. Transition to `ShutterState.Open`
+        or `ShutterState.Closed` when the operation completes successfully.
+
+        Return `ShutterState.Error` if the shutter encounters a problem or its
+        state cannot be determined.
+
+        Raise `PropertyNotImplementedException` if your dome does not have a
+        controllable shutter. In this case, `get_cansetshutter()` must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            The current ShutterState value.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_slaved(self, req: CommonRequest) -> bool:
+        """Return True if the dome is currently slaved to the telescope.
+
+        Return the current slaving state. When True, the dome automatically
+        tracks the telescope to keep the opening aligned with the telescope's
+        optical path.
+
+        Raise `PropertyNotImplementedException` if your dome is not part of an
+        integrated telescope/dome control system. In this case, `get_canslave()`
+        must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if currently slaved, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_slaved(self, req: PutSlavedRequest) -> None:
+        """Enable or disable telescope slaving.
+
+        Enable or disable automatic dome slaving to the telescope. When enabled,
+        your dome should automatically track the telescope to keep the opening
+        aligned with the telescope's optical path.
+
+        Raise `PropertyNotImplementedException` if your dome is not part of an
+        integrated telescope/dome control system. In this case, `get_canslave()`
+        must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request with `Slaved` indicating the desired state.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_slewing(self, req: CommonRequest) -> bool:
+        """Return True if any part of the dome is moving.
+
+        Return whether any dome component is currently in motion. This includes
+        azimuth rotation, altitude adjustment, shutter opening/closing, or any
+        other mechanical movement.
+
+        This is the correct property for clients to monitor completion of
+        asynchronous operations. Your implementation must:
+
+        - Return True immediately after `put_slewtoazimuth()` starts a slew
+        - Return True immediately after `put_slewtoaltitude()` starts a slew
+        - Return True immediately after `put_findhome()` starts homing
+        - Return True immediately after `put_park()` starts parking
+        - Return True while shutter is opening or closing
+        - Return False only when all motion has stopped
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+
+        Returns:
+            True if any dome component is moving, False otherwise.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_abortslew(self, req: CommonRequest) -> None:
+        """Immediately stop all dome motion.
+
+        Stop any dome movement currently in progress. This includes azimuth
+        rotation, altitude adjustment, shutter opening/closing, and any other
+        mechanical motion.
+
+        This is an asynchronous (non-blocking) method. Return immediately after
+        initiating the stop. Clients should monitor `get_slewing()` to determine
+        when all motion has actually stopped.
+
+        Your implementation should also disable slaving when aborting - after
+        abort completes, `get_slaved()` should return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_closeshutter(self, req: CommonRequest) -> None:
+        """Start closing the shutter or roof.
+
+        Begin closing the dome shutter or roll-off roof. This is an asynchronous
+        (non-blocking) method - return immediately after successfully starting
+        the close operation.
+
+        Your implementation must:
+
+        - Set shutter status to `ShutterState.Closing` before returning
+        - Transition to `ShutterState.Closed` when fully closed
+        - Set `get_slewing()` to True while closing
+
+        Clients monitor progress via `get_shutterstatus()`.
+
+        Raise `MethodNotImplementedException` if your dome does not have a
+        controllable shutter. In this case, `get_cansetshutter()` must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_findhome(self, req: CommonRequest) -> None:
+        """Start searching for the dome's home position.
+
+        Begin a search for the dome's home position and synchronize the azimuth.
+        This is an asynchronous (non-blocking) method - return immediately after
+        successfully starting the homing operation.
+
+        Your implementation must:
+
+        - Set `get_slewing()` to True before returning
+        - Synchronize `get_azimuth()` when home is found
+        - Set `get_slewing()` to False when complete
+        - Set `get_athome()` to True when complete
+
+        Clients monitor progress via `get_slewing()`, not `get_athome()`.
+
+        Raise `MethodNotImplementedException` if your dome does not support
+        homing. In this case, `get_canfindhome()` must return False.
+
+        Raise `SlavedException` if `get_slaved()` is True.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_openshutter(self, req: CommonRequest) -> None:
+        """Start opening the shutter or roof.
+
+        Begin opening the dome shutter or roll-off roof to expose the telescope
+        to the sky. This is an asynchronous (non-blocking) method - return
+        immediately after successfully starting the open operation.
+
+        Your implementation must:
+
+        - Set shutter status to `ShutterState.Opening` before returning
+        - Transition to `ShutterState.Open` when fully open
+        - Set `get_slewing()` to True while opening
+
+        Clients monitor progress via `get_shutterstatus()`.
+
+        Raise `MethodNotImplementedException` if your dome does not have a
+        controllable shutter. In this case, `get_cansetshutter()` must return False.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_park(self, req: CommonRequest) -> None:
+        """Start slewing the dome to its park position.
+
+        Begin slewing the dome to its programmed park position. This is an
+        asynchronous (non-blocking) method - return immediately after successfully
+        starting the park operation.
+
+        Your implementation must:
+
+        - Set `get_slewing()` to True before returning
+        - Set `get_slewing()` to False when the park position is reached
+        - Set `get_atpark()` to True when the park position is reached
+
+        Clients monitor progress via `get_slewing()`, not `get_atpark()`.
+
+        Raise `MethodNotImplementedException` if your dome does not support
+        parking. In this case, `get_canpark()` must return False.
+
+        Raise `ParkedException` if `get_atpark()` is already True.
+
+        Raise `SlavedException` if `get_slaved()` is True.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_setpark(self, req: CommonRequest) -> None:
+        """Set the current azimuth as the park position.
+
+        Record the current dome azimuth as the park position. Future calls to
+        `put_park()` will slew to this position.
+
+        Raise `MethodNotImplementedException` if your dome does not support
+        setting the park position. In this case, `get_cansetpark()` must return
+        False.
+
+        Raise `SlavedException` if `get_slaved()` is True.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request object containing client information.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_slewtoaltitude(self, req: PutAltitudeRequest) -> None:
+        """Start slewing to the requested altitude.
+
+        Begin slewing the dome opening to the requested viewing altitude. This
+        is an asynchronous (non-blocking) method - return immediately after
+        successfully starting the slew.
+
+        Your implementation must:
+
+        - Set `get_slewing()` to True before returning
+        - Set `get_slewing()` to False when the altitude is reached
+        - Accept the requested altitude even if the shutter is closed
+
+        Clients monitor progress via `get_slewing()`, not `get_altitude()`.
+
+        The altitude value is in degrees from 0 (horizon) to 90 (zenith).
+
+        Raise `MethodNotImplementedException` if your dome does not support
+        altitude control. In this case, `get_cansetaltitude()` must return False.
+
+        Raise `InvalidValueException` if the altitude is outside the valid
+        range for your hardware.
+
+        Raise `SlavedException` if `get_slaved()` is True.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request with `Altitude` in degrees (0-90).
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_slewtoazimuth(self, req: PutAzimuthRequest) -> None:
+        """Start slewing to the requested azimuth.
+
+        Begin slewing the dome to the requested viewing azimuth. This is an
+        asynchronous (non-blocking) method - return immediately after successfully
+        starting the slew.
+
+        Your implementation must:
+
+        - Set `get_slewing()` to True before returning
+        - Set `get_slewing()` to False when the azimuth is reached
+        - Accept the requested azimuth even if the shutter is closed
+
+        Clients monitor progress via `get_slewing()`, not `get_azimuth()`.
+
+        Azimuth uses the standard convention: 0 is North, 90 is East, 180 is
+        South, 270 is West.
+
+        Raise `MethodNotImplementedException` if your dome does not support
+        azimuth control. In this case, `get_cansetazimuth()` must return False.
+
+        Raise `InvalidValueException` if the azimuth is outside the valid
+        range (0-360 degrees).
+
+        Raise `SlavedException` if `get_slaved()` is True.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request with `Azimuth` in degrees (0-360).
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_synctoazimuth(self, req: PutAzimuthRequest) -> None:
+        """Synchronize the dome's azimuth to the given value.
+
+        Set the dome's current azimuth reading to the specified value without
+        physically moving the dome. Use this to correct encoder drift or
+        calibrate the azimuth position.
+
+        Azimuth uses the standard convention: 0 is North, 90 is East, 180 is
+        South, 270 is West.
+
+        Raise `MethodNotImplementedException` if your dome does not support
+        azimuth synchronization. In this case, `get_cansyncazimuth()` must
+        return False.
+
+        Raise `InvalidValueException` if the azimuth is outside the valid
+        range (0-360 degrees).
+
+        Raise `SlavedException` if `get_slaved()` is True.
+
+        Raise `NotConnectedException` if the device is not connected.
+
+        Args:
+            req: The Alpaca request with `Azimuth` in degrees (0-360).
+        """
         raise NotImplementedError(req)

--- a/python_alpaca_server/devices/filterwheel.py
+++ b/python_alpaca_server/devices/filterwheel.py
@@ -6,21 +6,137 @@ from ..request import CommonRequest, PutPositionRequest
 
 
 class FilterWheel(Device):
+    """Base class for ASCOM Alpaca FilterWheel devices.
+
+    Implement this class to create a filter wheel driver. A filter wheel holds
+    multiple optical filters and allows switching between them by rotating to
+    different positions.
+
+    **Position Indexing:**
+
+    Filter positions are 0-indexed. A wheel with N filters has valid positions
+    0 through N-1. The number of filters can be determined from the length of
+    the arrays returned by `get_names()` or `get_focusoffsets()`.
+
+    **Async Movement:**
+
+    Filter wheel movement is asynchronous (non-blocking). When `put_position()`
+    is called, it should start the rotation and return immediately. During
+    movement, `get_position()` must return -1. Once the wheel reaches the
+    target position and stops, `get_position()` returns the new position.
+
+    **Exception:** Some filter wheels are integrated into cameras and may not
+    physically rotate until an exposure is triggered. For these devices,
+    `get_position()` should immediately return the requested position after
+    `put_position()` is called, and -1 is never returned.
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.FilterWheel, unique_id)
 
     @abstractmethod
     def get_focusoffsets(self, req: CommonRequest) -> List[int]:
+        """Return the focus offset for each filter in the wheel.
+
+        Implement this to provide focus offsets that clients can use to adjust
+        focuser position when changing filters. Each filter may require a
+        different focus point due to optical path differences.
+
+        Your implementation should return a list with one entry per filter slot,
+        in position order (index 0 = filter 0, etc.). At least one filter must
+        have an offset of zero to serve as the reference for other offsets.
+
+        If focus offsets are not available or not applicable for your device,
+        return a list of zeros with the same length as the number of filters.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            A list of integer focus offsets, one per filter position. The length
+            of this list indicates the number of filter slots (N).
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_names(self, req: CommonRequest) -> List[str]:
+        """Return the name of each filter in the wheel.
+
+        Implement this to provide human-readable names for each filter slot.
+        Names help users identify filters (e.g., "Red", "Green", "Blue",
+        "H-alpha", "Luminance").
+
+        Your implementation should return a list with one entry per filter slot,
+        in position order (index 0 = filter 0, etc.).
+
+        If filter names are not available or not configured, return default
+        names in the format "Filter 1", "Filter 2", ... "Filter N" (note: 1-based
+        naming for display, but 0-based indexing for positions).
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            A list of filter name strings, one per filter position. The length
+            of this list indicates the number of filter slots (N).
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_position(self, req: CommonRequest) -> int:
+        """Return the current filter wheel position.
+
+        Implement this to report which filter is currently in the optical path.
+        Positions are 0-indexed (0 to N-1, where N is the number of filters).
+
+        Your implementation must return -1 while the wheel is rotating between
+        positions. Once the wheel reaches the target position and stops moving,
+        return the actual position number.
+
+        **Exception:** For filter wheels integrated into cameras that don't
+        physically rotate until exposure, return the last requested position
+        immediately (never return -1).
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            The current filter position (0 to N-1), or -1 if the wheel is
+            currently moving.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_position(self, req: PutPositionRequest) -> None:
+        """Start rotating the filter wheel to a new position.
+
+        Implement this to initiate filter wheel movement. This method must be
+        non-blocking: start the rotation and return immediately. Clients will
+        poll `get_position()` to detect completion (when it stops returning -1).
+
+        Your implementation should validate the position and raise
+        InvalidValueException if it is outside the valid range (0 to N-1).
+
+        Args:
+            req: The Alpaca request containing the target position in
+                `req.Position` (0 to N-1, where N is the number of filters).
+
+        Raises:
+            InvalidValueException: Raise if the position is outside the valid
+                range (0 to N-1).
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)

--- a/python_alpaca_server/devices/focuser.py
+++ b/python_alpaca_server/devices/focuser.py
@@ -5,53 +5,283 @@ from ..request import CommonRequest, PutPositionRequest, PutTempCompRequest
 
 
 class Focuser(Device):
+    """Base class for ASCOM Alpaca Focuser devices.
+
+    Implement this class to create a focuser driver. A focuser controls the
+    focus position of a telescope, either through absolute positioning (moving
+    to a specific step) or relative positioning (moving by a step offset).
+
+    Your implementation must define whether the focuser is absolute or relative
+    by implementing `get_absolute()`. This determines how `put_move()` interprets
+    its position parameter.
+
+    Movement Pattern:
+        Focuser movement is asynchronous. When `put_move()` is called, it should
+        start the motion and return immediately. Clients poll `get_ismoving()`
+        to determine when movement completes. Implement `put_halt()` to allow
+        emergency stops.
+
+    Temperature Compensation:
+        If your hardware supports automatic temperature compensation, implement
+        `get_tempcompavailable()` to return True and handle `get_tempcomp()` /
+        `put_tempcomp()` accordingly. If not supported, `get_tempcompavailable()`
+        should return False and `get_tempcomp()` should always return False.
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.Focuser, unique_id)
 
     @abstractmethod
     def get_absolute(self, req: CommonRequest) -> bool:
+        """Return whether this focuser uses absolute positioning.
+
+        Implement this to indicate your focuser's positioning mode. This value
+        determines how clients interpret the position parameter in `put_move()`:
+
+        - If True (absolute): positions are step numbers from 0 to `get_maxstep()`
+        - If False (relative): positions are step offsets from current position
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            True for absolute positioning, False for relative positioning.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_ismoving(self, req: CommonRequest) -> bool:
+        """Return whether the focuser is currently moving.
+
+        Implement this to query your hardware's motion state. Clients poll
+        this method to determine when a `put_move()` operation completes.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            True while moving, False when stationary.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_maxincrement(self, req: CommonRequest) -> int:
+        """Return the maximum step change allowed in a single move.
+
+        Implement this to report the largest step distance your focuser can
+        move in one `put_move()` call. For most focusers, this equals
+        `get_maxstep()`.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Maximum number of steps for a single move operation.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_maxstep(self, req: CommonRequest) -> int:
+        """Return the maximum focuser position in steps.
+
+        Implement this to report the travel range of your focuser. Valid
+        positions range from 0 to this value. If `put_move()` would exceed
+        these limits, the focuser should stop at the limit.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Maximum step position (focuser range is 0 to this value).
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_position(self, req: CommonRequest) -> int:
+        """Return the current focuser position in steps.
+
+        Implement this for absolute focusers to report the current step
+        position. For relative focusers, raise PropertyNotImplementedException.
+
+        Note: Clients should not use this to detect move completion. They
+        should poll `get_ismoving()` instead.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Current position as a step count from 0 to `get_maxstep()`.
+
+        Raises:
+            PropertyNotImplementedException: Raise if this is a relative
+                focuser (i.e., `get_absolute()` returns False).
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_stepsize(self, req: CommonRequest) -> float:
+        """Return the step size in microns.
+
+        Implement this if your focuser knows its physical step size. This
+        helps clients calculate focus in physical units rather than steps.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Size of one step in microns.
+
+        Raises:
+            PropertyNotImplementedException: Raise if step size is unknown.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_tempcomp(self, req: CommonRequest) -> bool:
+        """Return whether temperature compensation is enabled.
+
+        Implement this to report the current temperature compensation state.
+        If `get_tempcompavailable()` returns False, this must always return
+        False.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            True if temperature compensation is active, False otherwise.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_tempcomp(self, req: PutTempCompRequest) -> None:
+        """Enable or disable temperature compensation.
+
+        Implement this to control your focuser's temperature tracking mode.
+        When enabled, the focuser automatically adjusts position to compensate
+        for thermal expansion/contraction.
+
+        Args:
+            req: The Alpaca request containing the desired TempComp state
+                in `req.TempComp` (True to enable, False to disable).
+
+        Raises:
+            PropertyNotImplementedException: Raise if temperature compensation
+                is not supported (i.e., `get_tempcompavailable()` returns False).
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_tempcompavailable(self, req: CommonRequest) -> bool:
+        """Return whether temperature compensation is supported.
+
+        Implement this to indicate if your focuser hardware supports
+        temperature compensation. If False, `get_tempcomp()` must always
+        return False and `put_tempcomp()` must raise
+        PropertyNotImplementedException.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            True if temperature compensation can be enabled, False otherwise.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_temperature(self, req: CommonRequest) -> float:
+        """Return the current ambient temperature in degrees Celsius.
+
+        Implement this if your focuser has a temperature sensor. This value
+        is used for temperature compensation calculations and client display.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            Current temperature in degrees Celsius.
+
+        Raises:
+            PropertyNotImplementedException: Raise if no temperature sensor
+                is available.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_halt(self, req: CommonRequest) -> None:
+        """Immediately stop any focuser motion.
+
+        Implement this to provide emergency stop functionality. This method
+        must be synchronous and return quickly. If your focuser cannot be
+        halted programmatically, raise MethodNotImplementedException.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Raises:
+            MethodNotImplementedException: Raise if the focuser cannot be
+                programmatically halted.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_move(self, req: PutPositionRequest) -> None:
+        """Start moving the focuser to a new position.
+
+        Implement this to initiate focuser movement. This method must be
+        non-blocking: start the motion and return immediately. Clients will
+        poll `get_ismoving()` to detect completion.
+
+        The meaning of `req.Position` depends on `get_absolute()`:
+
+        - If absolute: move to step position (0 to `get_maxstep()`)
+        - If relative: move by step offset (-`get_maxincrement()` to
+          +`get_maxincrement()`)
+
+        Your implementation should validate the position and raise
+        InvalidValueException if out of range.
+
+        Args:
+            req: The Alpaca request containing the target position in
+                `req.Position`.
+
+        Raises:
+            InvalidValueException: Raise if the position is out of range
+                or would move beyond `get_maxstep()`.
+            NotConnectedException: Raise if the device is not connected.
+            DriverException: Raise for hardware communication errors.
+        """
         raise NotImplementedError(req)

--- a/python_alpaca_server/devices/observingconditions.py
+++ b/python_alpaca_server/devices/observingconditions.py
@@ -5,77 +5,426 @@ from ..request import CommonRequest, PutAveragePeriodRequest, SensorNameRequest
 
 
 class ObservingConditions(Device):
+    """Base class for ASCOM ObservingConditions devices.
+
+    Implement this class to create a weather station or environmental monitoring
+    device that reports atmospheric and sky conditions. Your implementation can
+    support any combination of sensors - raise PropertyNotImplementedException
+    for sensors your hardware does not provide.
+
+    Sensor properties and their units:
+        - Cloud cover: percent (0.0 - 100.0)
+        - Dew point: degrees Celsius
+        - Humidity: percent (0.0 - 100.0)
+        - Pressure: hectopascals (hPa) at observatory altitude
+        - Rain rate: millimeters per hour (mm/hr)
+        - Sky brightness: lux
+        - Sky quality: magnitudes per square arcsecond
+        - Sky temperature: degrees Celsius
+        - Star FWHM (seeing): arcseconds
+        - Temperature: degrees Celsius
+        - Wind direction: degrees (0-360, meteorological convention)
+        - Wind gust: meters per second (m/s)
+        - Wind speed: meters per second (m/s)
+
+    Note:
+        The ASCOM specification requires that `get_dewpoint()` and
+        `get_humidity()` are either both implemented or both raise
+        PropertyNotImplementedException.
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.ObservingConditions, unique_id)
 
     @abstractmethod
     def get_averageperiod(self, req: CommonRequest) -> float:
+        """Return the time period (hours) over which sensor values are averaged.
+
+        This is a mandatory property. Return 0.0 if your device delivers
+        instantaneous sensor readings without averaging.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            The averaging period in hours, or 0.0 for instantaneous readings.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_averageperiod(self, req: PutAveragePeriodRequest) -> None:
+        """Set the time period (hours) over which sensor values are averaged.
+
+        Implement this to allow clients to configure the averaging period for
+        sensor readings. Your implementation must accept 0.0 to specify that
+        instantaneous values should be returned.
+
+        Args:
+            req: The request containing the new averaging period in hours
+                via req.AveragePeriod.
+
+        Raises:
+            InvalidValueException: If the requested averaging period is not
+                supported by your hardware. All implementations must accept 0.0.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_cloudcover(self, req: CommonRequest) -> float:
+        """Return the amount of sky obscured by cloud.
+
+        Implement this if your device has a cloud sensor. The value represents
+        the percentage of sky covered by clouds.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Cloud cover as a percentage from 0.0 (clear sky) to 100.0
+            (completely overcast).
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a cloud sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_dewpoint(self, req: CommonRequest) -> float:
+        """Return the atmospheric dew point temperature.
+
+        Implement this if your device can measure or calculate dew point.
+        If you implement this, you must also implement `get_humidity()`.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Dew point temperature in degrees Celsius.
+
+        Raises:
+            PropertyNotImplementedException: If your device cannot provide
+                dew point. Must also raise this if `get_humidity()` raises it.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_humidity(self, req: CommonRequest) -> float:
+        """Return the atmospheric relative humidity.
+
+        Implement this if your device has a humidity sensor. If you implement
+        this, you must also implement `get_dewpoint()`.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Relative humidity as a percentage from 0.0 to 100.0.
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a humidity sensor. Must also raise this if `get_dewpoint()`
+                raises it.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_pressure(self, req: CommonRequest) -> float:
+        """Return the atmospheric pressure at the observatory altitude.
+
+        Implement this if your device has a barometric pressure sensor.
+        Your implementation must return the actual pressure at the observatory's
+        altitude, not the sea-level adjusted pressure.
+
+        If your sensor returns sea-level pressure, convert it to the actual
+        pressure at your observatory's altitude before returning.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Atmospheric pressure in hectopascals (hPa) at observatory altitude.
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a pressure sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_rainrate(self, req: CommonRequest) -> float:
+        """Return the rain rate at the observatory.
+
+        Implement this if your device has a rain sensor. The value can be
+        interpreted as: 0.0 = dry, any positive value = wet.
+
+        Reference rainfall intensity:
+            - Light rain: < 2.5 mm/hr
+            - Moderate rain: 2.5 - 10 mm/hr
+            - Heavy rain: 10 - 50 mm/hr
+            - Violent rain: > 50 mm/hr
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Rain rate in millimeters per hour (mm/hr).
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a rain sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_skybrightness(self, req: CommonRequest) -> float:
+        """Return the sky brightness at the observatory.
+
+        Implement this if your device has a light sensor measuring sky
+        brightness.
+
+        Reference values:
+            - 0.0001 lux: Moonless, overcast night (starlight)
+            - 0.002 lux: Moonless clear night with airglow
+            - 0.27-1.0 lux: Full moon, clear night
+            - 3.4 lux: Dark limit of civil twilight
+            - 100 lux: Very dark overcast day
+            - 1000 lux: Overcast day
+            - 10000-25000 lux: Full daylight (not direct sun)
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Sky brightness in lux.
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a sky brightness sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_skyquality(self, req: CommonRequest) -> float:
+        """Return the sky quality at the observatory.
+
+        Implement this if your device has a sky quality meter (SQM) or
+        similar sensor measuring sky darkness.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Sky quality in magnitudes per square arcsecond.
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a sky quality sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_skytemperature(self, req: CommonRequest) -> float:
+        """Return the sky temperature at the observatory.
+
+        Implement this if your device has an infrared sensor measuring sky
+        temperature. Lower temperatures generally indicate clearer skies.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Sky temperature in degrees Celsius.
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                an infrared sky temperature sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_starfwhm(self, req: CommonRequest) -> float:
+        """Return the seeing (star FWHM) at the observatory.
+
+        Implement this if your device can measure astronomical seeing
+        conditions.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Seeing as Full Width Half Maximum (FWHM) in arcseconds.
+
+        Raises:
+            PropertyNotImplementedException: If your device cannot measure
+                seeing.
+            ValueNotSetException: If seeing data is not currently available
+                (e.g., during daylight or cloudy conditions).
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_temperature(self, req: CommonRequest) -> float:
+        """Return the atmospheric temperature at the observatory.
+
+        Implement this if your device has a temperature sensor.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Atmospheric temperature in degrees Celsius.
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a temperature sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_winddirection(self, req: CommonRequest) -> float:
+        """Return the wind direction at the observatory.
+
+        Implement this if your device has a wind direction sensor. Use
+        meteorological convention: direction is where the wind is blowing
+        FROM, measured clockwise from True North.
+
+        Reference directions:
+            - North = 0 degrees
+            - East = 90 degrees
+            - South = 180 degrees
+            - West = 270 degrees
+
+        If wind speed is 0, return 0 for direction.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Wind direction in degrees (0.0 - 360.0).
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a wind direction sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_windgust(self, req: CommonRequest) -> float:
+        """Return the peak wind gust at the observatory.
+
+        Implement this if your device can measure wind gusts. The value
+        should represent the peak 3-second wind gust over the last 2 minutes.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Peak wind gust in meters per second (m/s).
+
+        Raises:
+            PropertyNotImplementedException: If your device cannot measure
+                wind gusts.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_windspeed(self, req: CommonRequest) -> float:
+        """Return the wind speed at the observatory.
+
+        Implement this if your device has an anemometer or wind speed sensor.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            Wind speed in meters per second (m/s).
+
+        Raises:
+            PropertyNotImplementedException: If your device does not have
+                a wind speed sensor.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_refresh(self, req: CommonRequest) -> None:
+        """Force the device to immediately query its hardware for fresh data.
+
+        Implement this to trigger an immediate sensor refresh. This should be
+        a short-lived synchronous call that initiates the refresh but does not
+        wait for long-running processes to complete. Clients should poll
+        `get_timesincelastupdate()` to determine when fresh data is available.
+
+        Args:
+            req: The request object containing client information.
+
+        Raises:
+            MethodNotImplementedException: If your device does not support
+                on-demand refresh.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_sensordescription(self, req: SensorNameRequest) -> str:
+        """Return a description of the sensor for the specified property.
+
+        Implement this to provide information about the sensors used by your
+        device. The description should identify the sensor hardware providing
+        the measurement.
+
+        Your implementation should:
+            - Return a description if the sensor is implemented, even if not
+              currently returning data
+            - Raise MethodNotImplementedException if the sensor is not
+              implemented at all
+            - Handle property names case-insensitively
+
+        Valid property names: CloudCover, DewPoint, Humidity, Pressure,
+        RainRate, SkyBrightness, SkyQuality, SkyTemperature, StarFWHM,
+        Temperature, WindDirection, WindGust, WindSpeed.
+
+        Args:
+            req: The request containing the property name via req.SensorName.
+
+        Returns:
+            A description of the sensor providing the specified measurement.
+
+        Raises:
+            MethodNotImplementedException: If the specified sensor is not
+                implemented by your device.
+            InvalidValueException: If the property name is not recognized.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_timesincelastupdate(self, req: SensorNameRequest) -> float:
+        """Return elapsed time since the specified sensor was last updated.
+
+        Implement this to report how stale sensor data is. This is particularly
+        useful after calling `put_refresh()` to determine when fresh data is
+        available.
+
+        Your implementation should:
+            - Return a negative value if no valid reading has ever been received
+            - If an empty string is passed for the property name, return the
+              time since the most recent update of ANY sensor
+            - Handle property names case-insensitively
+
+        Valid property names: CloudCover, DewPoint, Humidity, Pressure,
+        RainRate, SkyBrightness, SkyQuality, SkyTemperature, StarFWHM,
+        Temperature, WindDirection, WindGust, WindSpeed (or empty string
+        for any sensor).
+
+        Args:
+            req: The request containing the property name via req.SensorName.
+
+        Returns:
+            Elapsed time in seconds since the sensor was last updated, or
+            a negative value if no valid reading has ever been received.
+
+        Raises:
+            MethodNotImplementedException: If the specified sensor is not
+                implemented by your device.
+            InvalidValueException: If the property name is not recognized.
+        """
         raise NotImplementedError(req)

--- a/python_alpaca_server/devices/rotator.py
+++ b/python_alpaca_server/devices/rotator.py
@@ -5,57 +5,314 @@ from ..request import CommonRequest, PutPositionFloatRequest, PutReverseRequest
 
 
 class Rotator(Device):
+    """Base class for ASCOM Rotator devices.
+
+    Implement this class to create a rotator driver that controls the angular
+    position of an instrument (typically an imager) attached to a telescope.
+
+    Position vs MechanicalPosition
+    ------------------------------
+    Your implementation must track two related angles:
+
+    - **MechanicalPosition**: The raw physical angle of the rotator relative to
+      the optical axis. This never changes except through physical rotation.
+
+    - **Position**: The synced position angle, which may include an offset
+      established via `put_sync()`. If `put_sync()` has never been called,
+      Position equals MechanicalPosition.
+
+    The sync offset allows applications to work in equatorial position angle (PA)
+    coordinates after plate-solving, while your hardware tracks mechanical angles.
+    Your implementation must persist the sync offset across driver restarts and
+    device reboots.
+
+    Async Move Operations
+    ---------------------
+    All move methods (`put_move()`, `put_moveabsolute()`, `put_movemechanical()`)
+    are non-blocking. Your implementation should:
+
+    1. Validate the requested position
+    2. Update the target position
+    3. Start the physical rotation
+    4. Return immediately with `get_ismoving()` returning True
+    5. Set `get_ismoving()` to False only when motion completes
+
+    Position Range
+    --------------
+    All position values are in degrees, ranging from 0 to 360 (exclusive).
+    Your implementation should normalize angles to this range.
+
+    Cable Wrap Prevention
+    ---------------------
+    Your implementation must prevent cable wrapping. The rotator should be able
+    to move between any two angles without limits or dead zones, handling wrap
+    internally and transparently to the application.
+
+    Rotation Direction
+    ------------------
+    Normal rotation is counterclockwise as viewed from behind the rotator,
+    looking toward the sky. This matches the direction of increasing equatorial
+    position angle. When `get_reverse()` returns True, rotation direction is
+    reversed (clockwise).
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.Rotator, unique_id)
 
     @abstractmethod
     def get_canreverse(self, req: CommonRequest) -> bool:
+        """Return whether the rotation direction can be reversed.
+
+        Return True if your rotator supports the `put_reverse()` method to
+        change the direction of rotation.
+
+        Note:
+            Per the ASCOM specification, this must always return True.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_ismoving(self, req: CommonRequest) -> bool:
+        """Return whether the rotator is currently moving.
+
+        Return True if the rotator is in motion due to a call to `put_move()`,
+        `put_moveabsolute()`, or `put_movemechanical()`.
+
+        Your implementation should:
+
+        - Return True immediately after starting any move operation
+        - Continue returning True while the rotator is physically moving
+        - Return False only when the rotator has reached its target and stopped
+
+        Note:
+            This is the correct way for clients to determine when a non-blocking
+            move operation has completed. Do not rely on position matching the
+            target, as the position may transit through the target before settling.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_mechanicalposition(self, req: CommonRequest) -> float:
+        """Return the raw mechanical position in degrees.
+
+        Return the physical angle of the rotator relative to the optical axis,
+        as a float from 0.0 to less than 360.0 degrees.
+
+        This value is unaffected by any sync offset established via `put_sync()`.
+        It represents the actual physical orientation of the rotator hardware.
+
+        Use this for operations that require the physical rotation angle, such as
+        taking sky flats where the physical orientation matters.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_position(self, req: CommonRequest) -> float:
+        """Return the current position angle in degrees, including any sync offset.
+
+        Return the synced position angle as a float from 0.0 to less than 360.0
+        degrees. This value includes any offset established via `put_sync()`.
+
+        Your implementation should:
+
+        - Return MechanicalPosition if `put_sync()` has never been called
+        - Apply the sync offset if `put_sync()` has been called
+        - Persist the sync offset across driver restarts and device reboots
+
+        Note:
+            Do not use this to determine if a move has completed. The position
+            may transit through the target before settling. Use `get_ismoving()`
+            instead.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_reverse(self, req: CommonRequest) -> bool:
+        """Return whether rotation direction is reversed.
+
+        Return True if rotation is clockwise (opposite to normal). Normal
+        rotation is counterclockwise as viewed from behind the rotator, looking
+        toward the sky, which matches increasing equatorial position angle.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_reverse(self, req: PutReverseRequest) -> None:
+        """Set the rotation direction reversal state.
+
+        Set to True to reverse rotation direction (clockwise). Set to False for
+        normal counterclockwise rotation.
+
+        The `req.Reverse` field contains the desired reversal state.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_stepsize(self, req: CommonRequest) -> float:
+        """Return the minimum rotation step size in degrees.
+
+        Return the smallest angular increment that the rotator can achieve.
+
+        Raise:
+            PropertyNotImplementedException: If the rotator does not know its
+                step size.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_targetposition(self, req: CommonRequest) -> float:
+        """Return the target position angle in degrees.
+
+        Return the destination angle for the current or most recent move
+        operation, as a float from 0.0 to less than 360.0 degrees.
+
+        This value is updated immediately when `put_move()` or `put_moveabsolute()`
+        is called, before the physical rotation begins. It includes any sync
+        offset.
+
+        Raise:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_halt(self, req: CommonRequest) -> None:
+        """Immediately stop any rotator motion.
+
+        Stop any rotation currently in progress due to a previous `put_move()`,
+        `put_moveabsolute()`, or `put_movemechanical()` call.
+
+        Your implementation should:
+
+        - Stop motion as quickly as safely possible
+        - Return promptly (this should be synchronous and short-lived)
+        - Allow `get_ismoving()` to reflect the actual motion state
+
+        Note:
+            Clients may poll `get_ismoving()` after calling this to determine
+            when motion has actually stopped.
+
+        Raise:
+            MethodNotImplementedException: If halt is not supported.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_move(self, req: PutPositionFloatRequest) -> None:
+        """Start a relative rotation by the specified number of degrees.
+
+        Rotate by the angle specified in `req.Position` relative to the current
+        position. Positive values rotate counterclockwise (normal direction),
+        negative values rotate clockwise.
+
+        This is a non-blocking method. Your implementation should:
+
+        1. Calculate the new target: (current Position + req.Position) mod 360
+        2. Update the target position immediately
+        3. Start the physical rotation
+        4. Return immediately (do not wait for motion to complete)
+        5. Ensure `get_ismoving()` returns True until motion completes
+
+        Raise:
+            InvalidValueException: If the position value is invalid.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_moveabsolute(self, req: PutPositionFloatRequest) -> None:
+        """Start rotation to an absolute position angle in degrees.
+
+        Rotate to the angle specified in `req.Position`. This is the synced
+        position angle (including any offset from `put_sync()`), not the
+        mechanical position.
+
+        The position must be in the range 0.0 to less than 360.0 degrees.
+
+        This is a non-blocking method. Your implementation should:
+
+        1. Validate the requested position
+        2. Update the target position to req.Position
+        3. Start the physical rotation
+        4. Return immediately (do not wait for motion to complete)
+        5. Ensure `get_ismoving()` returns True until motion completes
+
+        Raise:
+            InvalidValueException: If the position is outside 0-360 range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_movemechanical(self, req: PutPositionFloatRequest) -> None:
+        """Start rotation to an absolute mechanical position in degrees.
+
+        Rotate to the mechanical angle specified in `req.Position`, ignoring any
+        sync offset. Use this for operations requiring a specific physical
+        orientation, such as taking sky flats.
+
+        The position must be in the range 0.0 to less than 360.0 degrees.
+
+        This is a non-blocking method. Your implementation should:
+
+        1. Validate the requested position
+        2. Start the physical rotation to the mechanical angle
+        3. Return immediately (do not wait for motion to complete)
+        4. Ensure `get_ismoving()` returns True until motion completes
+
+        Note:
+            Unlike `put_moveabsolute()`, this method ignores the sync offset and
+            moves directly to the physical angle.
+
+        Raise:
+            InvalidValueException: If the position is outside 0-360 range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_sync(self, req: PutPositionFloatRequest) -> None:
+        """Sync the rotator to the specified position angle without moving.
+
+        Set the current position to `req.Position` without physically rotating.
+        This establishes an offset between the mechanical position and the
+        reported position, allowing applications to work in equatorial position
+        angle coordinates.
+
+        The position must be in the range 0.0 to less than 360.0 degrees.
+
+        Your implementation should:
+
+        1. Calculate the sync offset: req.Position - MechanicalPosition
+        2. Store this offset persistently (survive restarts and reboots)
+        3. Apply this offset to all future `get_position()` calls
+        4. Use synced coordinates for `put_move()` and `put_moveabsolute()`
+
+        This is typically called after plate-solving to calibrate the rotator
+        to match the actual sky position angle.
+
+        Raise:
+            InvalidValueException: If the position is outside 0-360 range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)

--- a/python_alpaca_server/devices/safetymonitor.py
+++ b/python_alpaca_server/devices/safetymonitor.py
@@ -5,9 +5,63 @@ from ..request import CommonRequest
 
 
 class SafetyMonitor(Device):
+    """Base class for ASCOM SafetyMonitor devices.
+
+    A SafetyMonitor reports whether it is safe to operate the observatory. This
+    is the simplest ASCOM device type, with only a single required method:
+    `get_issafe()`.
+
+    **Safety Semantics:**
+
+    - ``True`` = safe to operate (e.g., weather is good, power is stable)
+    - ``False`` = unsafe to operate (e.g., bad weather, power issues)
+
+    **Multiple Monitors:**
+
+    Multiple SafetyMonitor devices can be used together to monitor different
+    aspects of observatory safety:
+
+    - Weather conditions (rain, wind, humidity, clouds)
+    - Power system status
+    - Door/enclosure sensors
+    - Emergency stop buttons
+
+    Automation software typically requires ALL safety monitors to report safe
+    before proceeding with operations.
+
+    **Implementation Notes:**
+
+    Your implementation must always return a definitive True or False value.
+    Do not raise PropertyNotImplementedException from `get_issafe()`.
+
+    Implement this class to create a concrete SafetyMonitor device by providing
+    an implementation for the `get_issafe()` method.
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.SafetyMonitor, unique_id)
 
     @abstractmethod
     def get_issafe(self, req: CommonRequest) -> bool:
+        """Return whether the monitored state is safe for use.
+
+        Implement this to report the current safety status. This is the primary
+        method for SafetyMonitor devices and must always return a definitive
+        True or False value.
+
+        Your implementation should:
+
+        - Return True if conditions are safe for observatory operations
+        - Return False if conditions are unsafe and operations should stop
+        - Never raise PropertyNotImplementedException
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            True if safe to operate, False if unsafe.
+
+        Raises:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)

--- a/python_alpaca_server/devices/switch.py
+++ b/python_alpaca_server/devices/switch.py
@@ -11,73 +11,398 @@ from ..request import (
 
 
 class Switch(Device):
+    """Base class for ASCOM Switch devices.
+
+    A Switch device manages one or more switches, which can be simple on/off
+    boolean switches or multi-state switches with a range of values. Switches
+    are numbered from 0 to MaxSwitch - 1.
+
+    **Switch Types:**
+
+    - **Boolean switches**: Simple on/off state. Use `get_getswitch()` and
+      `put_setswitch()` for boolean access. For these switches,
+      `get_minswitchvalue()` returns 0.0 and `get_maxswitchvalue()` returns 1.0.
+
+    - **Multi-state switches**: Support a range of values between
+      `get_minswitchvalue()` and `get_maxswitchvalue()` in steps of
+      `get_switchstep()`. Use `get_getswitchvalue()` and `put_setswitchvalue()`
+      for numeric access.
+
+    **Read-only vs Writable:**
+
+    Some switches are read-only sensors (e.g., limit switches). Check
+    `get_canwrite()` before attempting to set a switch value.
+
+    **Async Operations:**
+
+    For switches that take time to change state (e.g., motorized switches),
+    implement async operations. Check `get_canasync()` for async support, use
+    `put_setasync()` or `put_setasyncvalue()` to start the operation, and poll
+    `get_statechangecomplete()` to monitor progress.
+
+    Implement this class to create a concrete Switch device by providing
+    implementations for all abstract methods.
+    """
+
     def __init__(self, unique_id: str):
         super().__init__(DeviceType.Switch, unique_id)
 
     @abstractmethod
     def get_maxswitch(self, req: CommonRequest) -> int:
+        """Return the number of switches managed by this device.
+
+        Implement this to return the count of switches available. Switches are
+        numbered from 0 to MaxSwitch - 1.
+
+        Args:
+            req: The request object containing client information.
+
+        Returns:
+            The number of switches. Valid switch IDs are 0 to this value minus 1.
+
+        Raises:
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_canwrite(self, req: IdRequest) -> bool:
+        """Return whether the specified switch can be written to.
+
+        Implement this to indicate if the switch supports setting its state.
+        Read-only switches include limit switches and sensors that can only
+        report their state.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            True if the switch can be written to, False if read-only.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_getswitch(self, req: IdRequest) -> bool:
+        """Return the state of the specified switch as a boolean.
+
+        Implement this to return the on/off state of a switch. For multi-state
+        switches, return False if at minimum value, True otherwise.
+
+        Your implementation should not use this method to determine if an async
+        operation has completed; use `get_statechangecomplete()` instead.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            True if the switch is on, False if off.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            InvalidOperationException: If the switch state cannot be determined
+                (e.g., after power-up before state is known).
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_getswitchdescription(self, req: IdRequest) -> str:
+        """Return a description of the specified switch.
+
+        Implement this to provide a fuller description of the switch, suitable
+        for display in a tooltip or detailed view.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            A description string for the switch.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_getswitchname(self, req: IdRequest) -> str:
+        """Return the short name of the specified switch.
+
+        Implement this to provide a brief name for the switch, suitable for
+        display in a list or compact view.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            A short name string for the switch.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_getswitchvalue(self, req: IdRequest) -> float:
+        """Return the value of the specified switch as a float.
+
+        Implement this to return the numeric value of a switch. The value should
+        be between `get_minswitchvalue()` and `get_maxswitchvalue()`.
+
+        For boolean on/off switches, return `get_minswitchvalue()` if off, or
+        `get_maxswitchvalue()` if on.
+
+        Your implementation should not use this method to determine if an async
+        operation has completed; use `get_statechangecomplete()` instead.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            The current value of the switch.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            InvalidOperationException: If the switch value cannot be determined
+                (e.g., after power-up before state is known).
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_minswitchvalue(self, req: IdRequest) -> float:
+        """Return the minimum value for the specified switch.
+
+        Implement this to return the minimum allowed value for the switch. This
+        must be less than `get_maxswitchvalue()`.
+
+        For boolean on/off switches, return 0.0.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            The minimum value for the switch.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_maxswitchvalue(self, req: IdRequest) -> float:
+        """Return the maximum value for the specified switch.
+
+        Implement this to return the maximum allowed value for the switch. This
+        must be greater than `get_minswitchvalue()`.
+
+        For boolean on/off switches, return 1.0.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            The maximum value for the switch.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_switchstep(self, req: IdRequest) -> float:
+        """Return the step size for the specified switch.
+
+        Implement this to return the difference between successive values of the
+        switch. The step must be greater than zero.
+
+        The number of possible values is:
+        ``((MaxSwitchValue - MinSwitchValue) / SwitchStep) + 1``
+
+        For boolean on/off switches, return 1.0.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            The step size for the switch.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_setswitch(self, req: PutIdStateRequest) -> None:
+        """Set the specified switch to the given boolean state.
+
+        Implement this to set a switch to on (True) or off (False). After
+        setting, `get_getswitchvalue()` should return `get_maxswitchvalue()`
+        if True, or `get_minswitchvalue()` if False.
+
+        Args:
+            req: The request containing the switch ID and the desired state.
+
+        Raises:
+            MethodNotImplementedException: If `get_canwrite()` returns False
+                for this switch.
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_setswitchname(self, req: PutIdNameRequest) -> None:
+        """Set the name of the specified switch.
+
+        Implement this to allow clients to customize switch names. If your
+        device does not support client-defined names, raise
+        MethodNotImplementedException.
+
+        Args:
+            req: The request containing the switch ID and the new name.
+
+        Raises:
+            MethodNotImplementedException: If switch names cannot be set.
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_setswitchvalue(self, req: PutIdValueRequest) -> None:
+        """Set the specified switch to the given float value.
+
+        Implement this to set a switch to a specific numeric value. The value
+        must be between `get_minswitchvalue()` and `get_maxswitchvalue()`.
+
+        Args:
+            req: The request containing the switch ID and the desired value.
+
+        Raises:
+            MethodNotImplementedException: If `get_canwrite()` returns False
+                for this switch.
+            InvalidValueException: If the switch ID is out of range, or if the
+                value is outside the valid range for this switch.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_canasync(self, req: IdRequest) -> bool:
+        """Return whether the specified switch supports async operations.
+
+        Implement this to indicate if the switch can operate asynchronously.
+        Async operations are useful for switches that take time to change state
+        (e.g., motorized switches).
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            True if the switch supports async operations, False otherwise.
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def get_statechangecomplete(self, req: IdRequest) -> bool:
+        """Return whether an async state change has completed.
+
+        Implement this to report when a `put_setasync()` or `put_setasyncvalue()`
+        operation has finished. Poll this method to monitor async operation
+        progress.
+
+        Your implementation should return True if:
+        - No async operation is in progress, OR
+        - The last async operation completed successfully
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Returns:
+            True if the async operation has completed, False if still in progress.
+
+        Raises:
+            MethodNotImplementedException: If `get_canasync()` returns False
+                for this switch.
+            OperationCancelledException: If the operation was cancelled via
+                `put_cancelasync()`.
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_cancelasync(self, req: IdRequest) -> None:
+        """Cancel an in-progress async state change operation.
+
+        Implement this to abort an ongoing async operation started by
+        `put_setasync()` or `put_setasyncvalue()`. After cancellation,
+        `get_statechangecomplete()` should raise OperationCancelledException.
+
+        Args:
+            req: The request containing the switch ID (0 to MaxSwitch - 1).
+
+        Raises:
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_setasync(self, req: PutIdStateRequest) -> None:
+        """Asynchronously set the specified switch to the given boolean state.
+
+        Implement this to start an async operation that sets a switch to on
+        (True) or off (False). This method should return immediately after
+        starting the operation, with `get_statechangecomplete()` returning False.
+
+        When the operation completes, `get_statechangecomplete()` should return
+        True, and `get_getswitchvalue()` should return `get_maxswitchvalue()`
+        if True, or `get_minswitchvalue()` if False.
+
+        Args:
+            req: The request containing the switch ID and the desired state.
+
+        Raises:
+            MethodNotImplementedException: If `get_canasync()` returns False
+                for this switch.
+            InvalidValueException: If the switch ID is out of range.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)
 
     @abstractmethod
     def put_setasyncvalue(self, req: PutIdValueRequest) -> None:
+        """Asynchronously set the specified switch to the given float value.
+
+        Implement this to start an async operation that sets a switch to a
+        specific numeric value. This method should return immediately after
+        starting the operation, with `get_statechangecomplete()` returning False.
+
+        When the operation completes, `get_statechangecomplete()` should return
+        True.
+
+        Args:
+            req: The request containing the switch ID and the desired value.
+
+        Raises:
+            MethodNotImplementedException: If `get_canwrite()` or `get_canasync()`
+                returns False for this switch.
+            InvalidValueException: If the switch ID is out of range, or if the
+                value is outside the valid range for this switch.
+            NotConnectedException: If the device is not connected.
+        """
         raise NotImplementedError(req)


### PR DESCRIPTION
## Summary

- Adds comprehensive docstrings to all device base classes to help implementers
- Uses implementer-focused language ("Implement this to...", "Your implementation should...")
- References correct method names (`get_ismoving()` not "IsMoving")
- Documents async/non-blocking patterns, exceptions to raise, and implementation requirements

## Files Updated

| File | Description |
|------|-------------|
| `python_alpaca_server/device.py` | Base Device class with common methods |
| `python_alpaca_server/devices/focuser.py` | Focuser device (12 methods) |
| `python_alpaca_server/devices/covercalibrator.py` | CoverCalibrator device + enums |
| `python_alpaca_server/devices/switch.py` | Switch device (17 methods) |
| `python_alpaca_server/devices/dome.py` | Dome device (23 methods) + ShutterState enum |
| `python_alpaca_server/devices/filterwheel.py` | FilterWheel device (4 methods) |
| `python_alpaca_server/devices/observingconditions.py` | ObservingConditions device (17 methods) |
| `python_alpaca_server/devices/rotator.py` | Rotator device (14 methods) |
| `python_alpaca_server/devices/safetymonitor.py` | SafetyMonitor device (1 method) |

## Documentation Style

All docstrings follow Google-style format with:
- Class-level overview explaining the device type and implementation patterns
- Method docstrings with Args, Returns, and Raises sections
- Implementation guidance specific to each method
- References to related methods (e.g., "poll `get_ismoving()` to detect completion")