### PR TITLE
feat!: add Platform 7 common endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.3.0 (2026-01-09)
+
+### Feat
+
+- **switch**: add ISwitchV3 async endpoints
+- **covercalibrator**: add ICoverCalibratorV2 async endpoints (#18)
+- add command* router endpoints to common API (#17)
+
+### Fix
+
+- change Focuser.stepsize return type from int to float (#16)
+
 ## 1.2.0 (2026-01-09)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "python-alpaca-server"
 packages = [{include = "python_alpaca_server"}]
 readme = "README.md"
-version = "1.2.0"
+version = "1.3.0"
 
 [tool.poetry.dependencies]
 asyncudp = "^0.11.0"

--- a/python_alpaca_server/__init__.py
+++ b/python_alpaca_server/__init__.py
@@ -1,0 +1,3 @@
+from python_alpaca_server.device import StateValue
+
+__all__ = ["StateValue"]

--- a/python_alpaca_server/__main__.py
+++ b/python_alpaca_server/__main__.py
@@ -1,6 +1,8 @@
+from datetime import datetime, timezone
 from typing import List
 
 from .app import AlpacaServer, Description
+from .device import StateValue
 from .devices.safetymonitor import SafetyMonitor
 from .errors import NotImplementedError
 from .request import ActionRequest, CommandRequest, CommonRequest, PutConnectedRequest
@@ -52,6 +54,24 @@ class MySafetyMonitor(SafetyMonitor):
             return False
 
         return True
+
+    def put_connect(self, req: CommonRequest) -> None:
+        self._connected = True
+
+    def put_disconnect(self, req: CommonRequest) -> None:
+        self._connected = False
+
+    def get_connecting(self, req: CommonRequest) -> bool:
+        return False
+
+    def get_devicestate(self, req: CommonRequest) -> List[StateValue]:
+        return [
+            StateValue(Name="IsSafe", Value=self.get_issafe(req)),
+            StateValue(
+                Name="TimeStamp",
+                Value=datetime.now(timezone.utc).isoformat(),
+            ),
+        ]
 
 
 def get_server_description() -> Description:

--- a/python_alpaca_server/api/common.py
+++ b/python_alpaca_server/api/common.py
@@ -9,7 +9,7 @@ else:
 import structlog
 from fastapi import APIRouter, Depends, Form, Query
 
-from ..device import Device, common_device_finder
+from ..device import Device, StateValue, common_device_finder
 from ..errors import NotImplementedError
 from ..request import ActionRequest, CommandRequest, CommonRequest, PutConnectedRequest
 from ..response import Response, common_endpoint_parameters
@@ -139,6 +139,48 @@ def create_router(devices: List[Device]):
             device.put_command_string(req),
         )
 
+    async def put_connect(
+        req: Annotated[CommonRequest, Form()],
+        device: Device = Depends(common_device_finder(devices)),
+    ) -> Response[None]:
+        device.put_connect(req)
+
+        return Response[None].from_request(
+            req,
+            None,
+        )
+
+    async def put_disconnect(
+        req: Annotated[CommonRequest, Form()],
+        device: Device = Depends(common_device_finder(devices)),
+    ) -> Response[None]:
+        device.put_disconnect(req)
+
+        return Response[None].from_request(
+            req,
+            None,
+        )
+
+    async def get_connecting(
+        req: Annotated[CommonRequest, Query()],
+        device: Device = Depends(common_device_finder(devices)),
+    ) -> Response[bool]:
+
+        return Response[bool].from_request(
+            req,
+            device.get_connecting(req),
+        )
+
+    async def get_devicestate(
+        req: Annotated[CommonRequest, Query()],
+        device: Device = Depends(common_device_finder(devices)),
+    ) -> Response[List[StateValue]]:
+
+        return Response[List[StateValue]].from_request(
+            req,
+            device.get_devicestate(req),
+        )
+
     router.put(
         "/{device_type}/{device_number}/action",
         **common_endpoint_parameters,
@@ -199,5 +241,27 @@ def create_router(devices: List[Device]):
         "/{device_type}/{device_number}/commandstring",
         **common_endpoint_parameters,
     )(put_command_string)
+
+    router.put(
+        "/{device_type}/{device_number}/connect",
+        **common_endpoint_parameters,
+    )(put_connect)
+
+    router.put(
+        "/{device_type}/{device_number}/disconnect",
+        **common_endpoint_parameters,
+    )(put_disconnect)
+
+    router.get(
+        "/{device_type}/{device_number}/connecting",
+        **common_endpoint_parameters,
+        response_model=Response[bool],
+    )(get_connecting)
+
+    router.get(
+        "/{device_type}/{device_number}/devicestate",
+        **common_endpoint_parameters,
+        response_model=Response[List[StateValue]],
+    )(get_devicestate)
 
     return router

--- a/python_alpaca_server/device.py
+++ b/python_alpaca_server/device.py
@@ -1,7 +1,7 @@
 import sys
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import List, Optional
+from typing import Any, List, Optional
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
@@ -42,6 +42,21 @@ class UrlDeviceType(str, Enum):
     SafetyMonitor = "safetymonitor"
     Switch = "switch"
     Telescope = "telescope"
+
+
+class StateValue(BaseModel):
+    """A name/value pair for device state.
+
+    Used by ``get_devicestate()`` to return aggregated device state
+    for reduced polling overhead.
+
+    Attributes:
+        Name: The property name (e.g., "IsSafe", "Temperature").
+        Value: The property value. Can be any JSON-serializable type.
+    """
+
+    Name: str
+    Value: Any
 
 
 class Device(ABC):
@@ -321,6 +336,78 @@ class Device(ABC):
             actions are supported.
 
         Raises:
+            DriverException: Raise for unexpected errors.
+        """
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def put_connect(self, req: CommonRequest) -> None:
+        """Connect to the device asynchronously.
+
+        Implement this to initiate a non-blocking connection. On return,
+        ``get_connecting()`` must return True unless already connected.
+        Clients poll ``get_connecting()`` to determine when connection completes.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Raises:
+            DriverException: Raise if the connection cannot be initiated.
+        """
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def put_disconnect(self, req: CommonRequest) -> None:
+        """Disconnect from the device asynchronously.
+
+        Implement this to initiate a non-blocking disconnection. On return,
+        ``get_connecting()`` must return True unless already disconnected.
+        Clients poll ``get_connecting()`` to determine when disconnection completes.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Raises:
+            DriverException: Raise if the disconnection cannot be initiated.
+        """
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def get_connecting(self, req: CommonRequest) -> bool:
+        """Return whether an async connect/disconnect operation is in progress.
+
+        Implement this to indicate when ``put_connect()`` or ``put_disconnect()``
+        operations are still in progress. Return False when the operation
+        completes or if no async operation is active.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            True while connecting or disconnecting, False otherwise.
+
+        Raises:
+            DriverException: Raise for unexpected errors.
+        """
+        raise NotImplementedError(req)
+
+    @abstractmethod
+    def get_devicestate(self, req: CommonRequest) -> List["StateValue"]:
+        """Return aggregated device state for reduced polling.
+
+        Implement this to return a list of name/value pairs representing
+        the device's current operational state. The specific properties
+        returned depend on the device type.
+
+        Args:
+            req: The Alpaca request containing client/transaction IDs.
+
+        Returns:
+            List of StateValue objects with device-specific properties.
+            Include a "TimeStamp" entry with the current UTC time.
+
+        Raises:
+            NotConnectedException: Raise if the device is not connected.
             DriverException: Raise for unexpected errors.
         """
         raise NotImplementedError(req)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 from python_alpaca_server.app import AlpacaServer
 from python_alpaca_server.api.management import Description
-from python_alpaca_server.device import DeviceType
+from python_alpaca_server.device import DeviceType, StateValue
 from python_alpaca_server.devices.safetymonitor import SafetyMonitor
 from python_alpaca_server.devices.observingconditions import ObservingConditions
 from python_alpaca_server.devices.focuser import Focuser
@@ -76,6 +76,18 @@ class MockSafetyMonitor(SafetyMonitor):
 
     def get_issafe(self, req):
         return True
+
+    def put_connect(self, req):
+        pass
+
+    def put_disconnect(self, req):
+        pass
+
+    def get_connecting(self, req):
+        return False
+
+    def get_devicestate(self, req) -> List[StateValue]:
+        return [StateValue(Name="IsSafe", Value=True)]
 
 
 class MockObservingConditions(ObservingConditions):
@@ -174,6 +186,18 @@ class MockObservingConditions(ObservingConditions):
     def get_timesincelastupdate(self, req):
         return 0.0
 
+    def put_connect(self, req):
+        pass
+
+    def put_disconnect(self, req):
+        pass
+
+    def get_connecting(self, req):
+        return False
+
+    def get_devicestate(self, req) -> List[StateValue]:
+        return [StateValue(Name="Temperature", Value=20.0)]
+
 
 class MockFocuser(Focuser):
     """Minimal Focuser implementation for testing."""
@@ -252,6 +276,18 @@ class MockFocuser(Focuser):
 
     def put_move(self, req):
         pass
+
+    def put_connect(self, req):
+        pass
+
+    def put_disconnect(self, req):
+        pass
+
+    def get_connecting(self, req):
+        return False
+
+    def get_devicestate(self, req) -> List[StateValue]:
+        return [StateValue(Name="Position", Value=25000)]
 
 
 def _get_route_paths(app) -> List[str]:

--- a/tests/test_platform7.py
+++ b/tests/test_platform7.py
@@ -1,0 +1,293 @@
+"""Tests for Platform 7 common endpoints (connect, disconnect, connecting, devicestate)."""
+
+from typing import List
+
+import pytest
+from fastapi.testclient import TestClient
+
+from python_alpaca_server.app import AlpacaServer
+from python_alpaca_server.api.management import Description
+from python_alpaca_server.device import StateValue
+from python_alpaca_server.devices.safetymonitor import SafetyMonitor
+from python_alpaca_server.request import CommonRequest
+
+
+def _server_description() -> Description:
+    """Create a test server description."""
+    return Description(
+        ServerName="Test Server",
+        Manufacturer="Test",
+        ManufacturerVersion="1.0.0",
+        Location="Test Location",
+    )
+
+
+class MockSafetyMonitor(SafetyMonitor):
+    """Minimal SafetyMonitor implementation for testing Platform 7 endpoints."""
+
+    def __init__(self):
+        super().__init__("test-safety-monitor")
+        self._connected = False
+        self._connecting = False
+
+    def put_action(self, req):
+        return ""
+
+    def put_command_blind(self, req):
+        pass
+
+    def put_command_bool(self, req):
+        return False
+
+    def put_command_string(self, req):
+        return ""
+
+    def get_connected(self, req):
+        return self._connected
+
+    def put_connected(self, req):
+        self._connected = req.Connected
+
+    def get_description(self, req):
+        return "Test SafetyMonitor"
+
+    def get_driverinfo(self, req):
+        return "Test Driver"
+
+    def get_driverversion(self, req):
+        return "1.0"
+
+    def get_interfaceversion(self, req):
+        return 1
+
+    def get_name(self, req):
+        return "Test SafetyMonitor"
+
+    def get_supportedactions(self, req):
+        return []
+
+    def get_issafe(self, req):
+        return True
+
+    # Platform 7 methods
+    def put_connect(self, req: CommonRequest) -> None:
+        self._connecting = True
+        self._connected = True
+        self._connecting = False
+
+    def put_disconnect(self, req: CommonRequest) -> None:
+        self._connecting = True
+        self._connected = False
+        self._connecting = False
+
+    def get_connecting(self, req: CommonRequest) -> bool:
+        return self._connecting
+
+    def get_devicestate(self, req: CommonRequest) -> List[StateValue]:
+        return [
+            StateValue(Name="IsSafe", Value=True),
+            StateValue(Name="TimeStamp", Value="2024-01-01T00:00:00Z"),
+        ]
+
+
+class TestPlatform7Routes:
+    """Tests for Platform 7 route registration."""
+
+    def test_connect_route_registered(self):
+        """PUT connect route is registered for all device types."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+
+        routes = [route.path for route in app.routes]
+
+        assert "/api/v1/{device_type}/{device_number}/connect" in routes
+
+    def test_disconnect_route_registered(self):
+        """PUT disconnect route is registered for all device types."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+
+        routes = [route.path for route in app.routes]
+
+        assert "/api/v1/{device_type}/{device_number}/disconnect" in routes
+
+    def test_connecting_route_registered(self):
+        """GET connecting route is registered for all device types."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+
+        routes = [route.path for route in app.routes]
+
+        assert "/api/v1/{device_type}/{device_number}/connecting" in routes
+
+    def test_devicestate_route_registered(self):
+        """GET devicestate route is registered for all device types."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+
+        routes = [route.path for route in app.routes]
+
+        assert "/api/v1/{device_type}/{device_number}/devicestate" in routes
+
+
+class TestConnectEndpoint:
+    """Tests for the PUT connect endpoint."""
+
+    def test_connect_endpoint_accessible(self):
+        """PUT connect endpoint is accessible and returns success."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.put("/api/v1/safetymonitor/0/connect", data={})
+
+        assert response.status_code == 200
+        data = response.json()
+        # ErrorNumber should be excluded when None (no error)
+        assert "ErrorNumber" not in data or data["ErrorNumber"] == 0
+
+    def test_connect_initiates_connection(self):
+        """PUT connect initiates device connection."""
+        mock_device = MockSafetyMonitor()
+        server = AlpacaServer(_server_description(), [mock_device])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # Device should start disconnected
+        assert mock_device._connected is False
+
+        response = client.put("/api/v1/safetymonitor/0/connect", data={})
+
+        assert response.status_code == 200
+        # After connect, device should be connected
+        assert mock_device._connected is True
+
+
+class TestDisconnectEndpoint:
+    """Tests for the PUT disconnect endpoint."""
+
+    def test_disconnect_endpoint_accessible(self):
+        """PUT disconnect endpoint is accessible and returns success."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.put("/api/v1/safetymonitor/0/disconnect", data={})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "ErrorNumber" not in data or data["ErrorNumber"] == 0
+
+    def test_disconnect_terminates_connection(self):
+        """PUT disconnect terminates device connection."""
+        mock_device = MockSafetyMonitor()
+        mock_device._connected = True
+        server = AlpacaServer(_server_description(), [mock_device])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # Device should start connected
+        assert mock_device._connected is True
+
+        response = client.put("/api/v1/safetymonitor/0/disconnect", data={})
+
+        assert response.status_code == 200
+        # After disconnect, device should be disconnected
+        assert mock_device._connected is False
+
+
+class TestConnectingEndpoint:
+    """Tests for the GET connecting endpoint."""
+
+    def test_connecting_endpoint_accessible(self):
+        """GET connecting endpoint is accessible and returns boolean."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/api/v1/safetymonitor/0/connecting")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Value" in data
+        assert isinstance(data["Value"], bool)
+
+    def test_connecting_returns_false_when_idle(self):
+        """GET connecting returns False when no async operation is active."""
+        mock_device = MockSafetyMonitor()
+        server = AlpacaServer(_server_description(), [mock_device])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/api/v1/safetymonitor/0/connecting")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["Value"] is False
+
+
+class TestDeviceStateEndpoint:
+    """Tests for the GET devicestate endpoint."""
+
+    def test_devicestate_endpoint_accessible(self):
+        """GET devicestate endpoint is accessible and returns list."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/api/v1/safetymonitor/0/devicestate")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Value" in data
+        assert isinstance(data["Value"], list)
+
+    def test_devicestate_returns_state_values(self):
+        """GET devicestate returns StateValue objects with Name and Value."""
+        server = AlpacaServer(_server_description(), [MockSafetyMonitor()])
+        app = server.create_app(5555)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/api/v1/safetymonitor/0/devicestate")
+
+        assert response.status_code == 200
+        data = response.json()
+        state_values = data["Value"]
+        assert len(state_values) == 2
+
+        # Check that state values have correct structure
+        names = [sv["Name"] for sv in state_values]
+        assert "IsSafe" in names
+        assert "TimeStamp" in names
+
+        # Check IsSafe value
+        is_safe = next(sv for sv in state_values if sv["Name"] == "IsSafe")
+        assert is_safe["Value"] is True
+
+
+class TestStateValueModel:
+    """Tests for the StateValue model."""
+
+    def test_statevalue_creation(self):
+        """StateValue can be created with Name and Value."""
+        sv = StateValue(Name="TestProp", Value=42)
+        assert sv.Name == "TestProp"
+        assert sv.Value == 42
+
+    def test_statevalue_accepts_various_value_types(self):
+        """StateValue accepts various types for Value field."""
+        # String value
+        sv_str = StateValue(Name="StringProp", Value="hello")
+        assert sv_str.Value == "hello"
+
+        # Boolean value
+        sv_bool = StateValue(Name="BoolProp", Value=True)
+        assert sv_bool.Value is True
+
+        # Float value
+        sv_float = StateValue(Name="FloatProp", Value=3.14)
+        assert sv_float.Value == 3.14
+
+        # List value
+        sv_list = StateValue(Name="ListProp", Value=[1, 2, 3])
+        assert sv_list.Value == [1, 2, 3]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,10 +1,13 @@
 """Tests for Switch device switchstep property."""
 
+from typing import List
+
 import pytest
 from fastapi.testclient import TestClient
 
 from python_alpaca_server.app import AlpacaServer
 from python_alpaca_server.api.management import Description
+from python_alpaca_server.device import StateValue
 from python_alpaca_server.devices.switch import Switch
 from python_alpaca_server.request import (
     CommonRequest,
@@ -118,6 +121,18 @@ class MockSwitch(Switch):
 
     def put_setasyncvalue(self, req: PutIdValueRequest) -> None:
         pass
+
+    def put_connect(self, req):
+        pass
+
+    def put_disconnect(self, req):
+        pass
+
+    def get_connecting(self, req):
+        return False
+
+    def get_devicestate(self, req) -> List[StateValue]:
+        return [StateValue(Name="MaxSwitch", Value=4)]
 
 
 class TestSwitchStepProperty:


### PR DESCRIPTION
## Summary
- Add `StateValue` model for aggregated device state
- Add 4 new abstract methods to `Device` class: `put_connect()`, `put_disconnect()`, `get_connecting()`, `get_devicestate()`
- Add 4 new router endpoints for Platform 7 async connection management
- Update all test mocks to implement the new methods
- Export `StateValue` from package public API

## BREAKING CHANGE

Device implementations must now implement these 4 new abstract methods:
- `put_connect(req: CommonRequest) -> None`
- `put_disconnect(req: CommonRequest) -> None`  
- `get_connecting(req: CommonRequest) -> bool`
- `get_devicestate(req: CommonRequest) -> List[StateValue]`

Fixes #13

## Test plan
- [x] All existing tests pass
- [x] New Platform 7 endpoint tests pass
- [x] Lint passes
- [x] Type check passes